### PR TITLE
Add customizable Phaze-A model with additional upscalers

### DIFF
--- a/lib/cli/args_train.py
+++ b/lib/cli/args_train.py
@@ -114,7 +114,8 @@ class TrainArgs(FaceSwapArgs):
                 "unbalanced so B>A swaps won't work so well. Very configurable."
                 "\nL|villain: 128px in/out model from villainguy. Very resource hungry (You will "
                 "require a GPU with a fair amount of VRAM). Good for details, but more "
-                "susceptible to color differences.")})
+                "susceptible to color differences."
+                "\nL|phaze-a-custom: Customizable Phaze-A model exposing additional upscalers.")})
         argument_list.append({
             "opts": ("-u", "--summary"),
             "action": "store_true",

--- a/plugins/train/model/phaze_a_custom.py
+++ b/plugins/train/model/phaze_a_custom.py
@@ -1,0 +1,1352 @@
+#!/usr/bin/env python3
+""" Phaze-A Custom Model
+
+This variant of the Phaze-A model exposes additional upscalers and is provided as a
+customizable example. It is based on the original implementation by TorzDF with
+thanks to BirbFakes and the myriad of testers.
+"""
+
+# pylint:disable=too-many-lines
+from __future__ import annotations
+import logging
+import typing as T
+from dataclasses import dataclass
+
+import numpy as np
+import tensorflow as tf
+
+from lib.model.nn_blocks import (
+    Conv2D, Conv2DBlock, Conv2DOutput, ResidualBlock, UpscaleBlock, Upscale2xBlock,
+    UpscaleResizeImagesBlock, UpscaleDNYBlock)
+from lib.model.normalization import (
+    AdaInstanceNormalization, GroupNormalization, InstanceNormalization, RMSNormalization)
+from lib.model.networks import ViT, TypeModelsViT
+from lib.utils import get_tf_version, FaceswapError
+
+from ._base import ModelBase, get_all_sub_models
+
+logger = logging.getLogger(__name__)
+
+K = tf.keras.backend
+kapp = tf.keras.applications
+kl = tf.keras.layers
+keras = tf.keras
+
+
+@dataclass
+class _EncoderInfo:
+    """ Contains model configuration options for various Phaze-A Encoders.
+
+    Parameters
+    ----------
+    keras_name: str
+        The name of the encoder in Keras Applications. Empty string `""` if the encoder does not
+        exist in Keras Applications
+    default_size: int
+        The default input size of the encoder
+    tf_min: float, optional
+        The lowest version of Tensorflow that the encoder can be used for. Default: `2.0`
+    scaling: tuple, optional
+        The float scaling that the encoder expects. Default: `(0, 1)`
+    min_size: int, optional
+        The minimum input size that the encoder will allow. Default: 32
+    enforce_for_weights: bool, optional
+        ``True`` if the input size for the model must be forced to the default size when loading
+        imagenet weights, otherwise ``False``. Default: ``False``
+    color_order: str, optional
+        The color order that the model expects (`"bgr"` or `"rgb"`). Default: `"rgb"`
+    """
+    keras_name: str
+    default_size: int
+    tf_min: tuple[int, int] = (2, 0)
+    scaling: tuple[int, int] = (0, 1)
+    min_size: int = 32
+    enforce_for_weights: bool = False
+    color_order: T.Literal["bgr", "rgb"] = "rgb"
+
+
+_MODEL_MAPPING: dict[str, _EncoderInfo] = {
+    "clipv_farl-b-16-16": _EncoderInfo(
+        keras_name="FaRL-B-16-16", default_size=224),
+    "clipv_farl-b-16-64": _EncoderInfo(
+        keras_name="FaRL-B-16-64", default_size=224),
+    "clipv_vit-b-16": _EncoderInfo(
+        keras_name="ViT-B-16", default_size=224),
+    "clipv_vit-b-32": _EncoderInfo(
+        keras_name="ViT-B-32", default_size=224),
+    "clipv_vit-l-14": _EncoderInfo(
+        keras_name="ViT-L-14", default_size=224),
+    "clipv_vit-l-14-336px": _EncoderInfo(
+        keras_name="ViT-L-14-336px", default_size=336),
+    "densenet121": _EncoderInfo(
+        keras_name="DenseNet121", default_size=224),
+    "densenet169": _EncoderInfo(
+        keras_name="DenseNet169", default_size=224),
+    "densenet201": _EncoderInfo(
+        keras_name="DenseNet201", default_size=224),
+    "efficientnet_b0": _EncoderInfo(
+        keras_name="EfficientNetB0", tf_min=(2, 3), scaling=(0, 255), default_size=224),
+    "efficientnet_b1": _EncoderInfo(
+        keras_name="EfficientNetB1", tf_min=(2, 3), scaling=(0, 255), default_size=240),
+    "efficientnet_b2": _EncoderInfo(
+        keras_name="EfficientNetB2", tf_min=(2, 3), scaling=(0, 255), default_size=260),
+    "efficientnet_b3": _EncoderInfo(
+        keras_name="EfficientNetB3", tf_min=(2, 3), scaling=(0, 255), default_size=300),
+    "efficientnet_b4": _EncoderInfo(
+        keras_name="EfficientNetB4", tf_min=(2, 3), scaling=(0, 255), default_size=380),
+    "efficientnet_b5": _EncoderInfo(
+        keras_name="EfficientNetB5", tf_min=(2, 3), scaling=(0, 255), default_size=456),
+    "efficientnet_b6": _EncoderInfo(
+        keras_name="EfficientNetB6", tf_min=(2, 3), scaling=(0, 255), default_size=528),
+    "efficientnet_b7": _EncoderInfo(
+        keras_name="EfficientNetB7", tf_min=(2, 3), scaling=(0, 255), default_size=600),
+    "efficientnet_v2_b0": _EncoderInfo(
+        keras_name="EfficientNetV2B0", tf_min=(2, 8), scaling=(-1, 1), default_size=224),
+    "efficientnet_v2_b1": _EncoderInfo(
+        keras_name="EfficientNetV2B1", tf_min=(2, 8), scaling=(-1, 1), default_size=240),
+    "efficientnet_v2_b2": _EncoderInfo(
+        keras_name="EfficientNetV2B2", tf_min=(2, 8), scaling=(-1, 1), default_size=260),
+    "efficientnet_v2_b3": _EncoderInfo(
+        keras_name="EfficientNetV2B3", tf_min=(2, 8), scaling=(-1, 1), default_size=300),
+    "efficientnet_v2_s": _EncoderInfo(
+        keras_name="EfficientNetV2S", tf_min=(2, 8), scaling=(-1, 1), default_size=384),
+    "efficientnet_v2_m": _EncoderInfo(
+        keras_name="EfficientNetV2M", tf_min=(2, 8), scaling=(-1, 1), default_size=480),
+    "efficientnet_v2_l": _EncoderInfo(
+        keras_name="EfficientNetV2L", tf_min=(2, 8), scaling=(-1, 1), default_size=480),
+    "inception_resnet_v2": _EncoderInfo(
+        keras_name="InceptionResNetV2", scaling=(-1, 1), min_size=75, default_size=299),
+    "inception_v3": _EncoderInfo(
+        keras_name="InceptionV3", scaling=(-1, 1), min_size=75, default_size=299),
+    "mobilenet": _EncoderInfo(
+        keras_name="MobileNet", scaling=(-1, 1), default_size=224),
+    "mobilenet_v2": _EncoderInfo(
+        keras_name="MobileNetV2", scaling=(-1, 1), default_size=224),
+    "mobilenet_v3_large": _EncoderInfo(
+        keras_name="MobileNetV3Large", tf_min=(2, 4), scaling=(-1, 1), default_size=224),
+    "mobilenet_v3_small": _EncoderInfo(
+        keras_name="MobileNetV3Small", tf_min=(2, 4), scaling=(-1, 1), default_size=224),
+    "nasnet_large": _EncoderInfo(
+        keras_name="NASNetLarge", scaling=(-1, 1), default_size=331, enforce_for_weights=True),
+    "nasnet_mobile": _EncoderInfo(
+        keras_name="NASNetMobile", scaling=(-1, 1), default_size=224, enforce_for_weights=True),
+    "resnet50": _EncoderInfo(
+        keras_name="ResNet50", scaling=(-1, 1), min_size=32, default_size=224),
+    "resnet50_v2": _EncoderInfo(
+        keras_name="ResNet50V2", scaling=(-1, 1), default_size=224),
+    "resnet101": _EncoderInfo(
+        keras_name="ResNet101", scaling=(-1, 1), default_size=224),
+    "resnet101_v2": _EncoderInfo(
+        keras_name="ResNet101V2", scaling=(-1, 1), default_size=224),
+    "resnet152": _EncoderInfo(
+        keras_name="ResNet152", scaling=(-1, 1), default_size=224),
+    "resnet152_v2": _EncoderInfo(
+        keras_name="ResNet152V2", scaling=(-1, 1), default_size=224),
+    "vgg16": _EncoderInfo(
+        keras_name="VGG16", color_order="bgr", scaling=(0, 255), default_size=224),
+    "vgg19": _EncoderInfo(
+        keras_name="VGG19", color_order="bgr", scaling=(0, 255), default_size=224),
+    "xception": _EncoderInfo(
+        keras_name="Xception", scaling=(-1, 1), min_size=71, default_size=299),
+    "fs_original": _EncoderInfo(
+        keras_name="", color_order="bgr", min_size=32, default_size=1024)}
+
+
+class ModelCustom(ModelBase):
+    """ Phaze-A Custom Faceswap Model.
+
+    An highly adaptable and configurable model by torzDF. This custom variant allows
+    additional upscalers to be selected.
+
+    Parameters
+    ----------513
+    args: varies
+        The default command line arguments passed in from :class:`~scripts.train.Train` or
+        :class:`~scripts.train.Convert`
+    kwargs: varies
+        The default keyword arguments passed in from :class:`~scripts.train.Train` or
+        :class:`~scripts.train.Convert`
+    """
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        if self.config["output_size"] % 16 != 0:
+            raise FaceswapError("Phaze-A output shape must be a multiple of 16")
+
+        self._validate_encoder_architecture()
+        self.config["freeze_layers"] = self._select_freeze_layers()
+
+        self.input_shape: tuple[int, int, int] = self._get_input_shape()
+        self.color_order = _MODEL_MAPPING[self.config["enc_architecture"]].color_order
+
+    def build(self) -> None:
+        """ Build the model and assign to :attr:`model`.
+
+        Override's the default build function for allowing the setting of dropout rate for pre-
+        existing models.
+        """
+        is_summary = hasattr(self._args, "summary") and self._args.summary
+        if not self._io.model_exists or self._is_predict or is_summary:
+            logger.debug("New model, inference or summary. Falling back to default build: "
+                         "(exists: %s, inference: %s, is_summary: %s)",
+                         self._io.model_exists, self._is_predict, is_summary)
+            super().build()
+            return
+        with self._settings.strategy_scope():
+            model = self.io.load()
+            model = self._update_dropouts(model)
+            self._model = model
+            self._compile_model()
+            self._output_summary()
+
+    def _update_dropouts(self, model: tf.keras.models.Model) -> tf.keras.models.Model:
+        """ Update the saved model with new dropout rates.
+
+        Keras, annoyingly, does not actually change the dropout of the underlying layer, so we need
+        to update the rate, then clone the model into a new model and reload weights.
+
+        Parameters
+        ----------
+        model: :class:`keras.models.Model`
+            The loaded saved Keras Model to update the dropout rates for
+
+        Returns
+        -------
+        :class:`keras.models.Model`
+            The loaded Keras Model with the dropout rates updated
+        """
+        dropouts = {"fc": self.config["fc_dropout"],
+                    "gblock": self.config["fc_gblock_dropout"]}
+        logger.debug("Config dropouts: %s", dropouts)
+        updated = False
+        for mod in get_all_sub_models(model):
+            if not mod.name.startswith("fc_"):
+                continue
+            key = "gblock" if "gblock" in mod.name else mod.name.split("_")[0]
+            rate = dropouts[key]
+            log_once = False
+            for layer in mod.layers:
+                if not isinstance(layer, kl.Dropout):
+                    continue
+                if layer.rate != rate:
+                    logger.debug("Updating dropout rate for %s from %s to %s",
+                                 f"{mod.name} - {layer.name}", layer.rate, rate)
+                    if not log_once:
+                        logger.info("Updating Dropout Rate for '%s' from %s to %s",
+                                    mod.name, layer.rate, rate)
+                        log_once = True
+                    layer.rate = rate
+                    updated = True
+        if updated:
+            logger.debug("Dropout rate updated. Cloning model")
+            new_model = keras.models.clone_model(model)
+            new_model.set_weights(model.get_weights())
+            del model
+            model = new_model
+        return model
+
+    def _select_freeze_layers(self) -> list[str]:
+        """ Process the selected frozen layers and replace the `keras_encoder` option with the
+        actual keras model name
+
+        Returns
+        -------
+        list
+            The selected layers for weight freezing
+        """
+        arch = self.config["enc_architecture"]
+        layers = self.config["freeze_layers"]
+        # EfficientNetV2 is inconsistent with other model's naming conventions
+        keras_name = _MODEL_MAPPING[arch].keras_name.replace("EfficientNetV2", "EfficientNetV2-")
+        # CLIPv model is always called 'visual' regardless of weights/format loaded
+        keras_name = "visual" if arch.startswith("clipv_") else keras_name
+
+        if "keras_encoder" not in self.config["freeze_layers"]:
+            retval = layers
+        elif keras_name:
+            retval = [layer.replace("keras_encoder", keras_name.lower()) for layer in layers]
+            logger.debug("Substituting 'keras_encoder' for '%s'", arch)
+        else:
+            retval = [layer for layer in layers if layer != "keras_encoder"]
+            logger.debug("Removing 'keras_encoder' for '%s'", arch)
+
+        return retval
+
+    def _get_input_shape(self) -> tuple[int, int, int]:
+        """ Obtain the input shape for the model.
+
+        Input shape is calculated from the selected Encoder's input size, scaled to the user
+        selected Input Scaling, rounded down to the nearest 16 pixels.
+
+        Notes
+        -----
+        Some models (NasNet) require the input size to be of a certain dimension if loading
+        imagenet weights. In these instances resize inputs and raise warning message
+
+        Returns
+        -------
+        tuple
+            The shape tuple for the input size to the Phaze-A model
+        """
+        arch = self.config["enc_architecture"]
+        enforce_size = _MODEL_MAPPING[arch].enforce_for_weights
+        default_size = _MODEL_MAPPING[arch].default_size
+        scaling = self.config["enc_scaling"] / 100
+
+        min_size = _MODEL_MAPPING[arch].min_size
+        size = int(max(min_size, ((default_size * scaling) // 16) * 16))
+
+        if self.config["enc_load_weights"] and enforce_size and scaling != 1.0:
+            logger.warning("%s requires input size to be %spx when loading imagenet weights. "
+                           "Adjusting input size from %spx to %spx",
+                           arch, default_size, size, default_size)
+            retval = (default_size, default_size, 3)
+        else:
+            retval = (size, size, 3)
+
+        logger.debug("Encoder input set to: %s", retval)
+        return retval
+
+    def _validate_encoder_architecture(self) -> None:
+        """ Validate that the requested architecture is a valid choice for the running system
+        configuration.
+
+        If the selection is not valid, an error is logged and system exits.
+        """
+        arch = self.config["enc_architecture"].lower()
+        model = _MODEL_MAPPING.get(arch)
+        if not model:
+            raise FaceswapError(f"'{arch}' is not a valid choice for encoder architecture. Choose "
+                                f"one of {list(_MODEL_MAPPING.keys())}.")
+
+        tf_ver = get_tf_version()
+        tf_min = model.tf_min
+        if tf_ver < tf_min:
+            raise FaceswapError(f"{arch}' is not compatible with your version of Tensorflow. The "
+                                f"minimum version required is {tf_min} whilst you have version "
+                                f"{tf_ver} installed.")
+
+    def build_model(self, inputs: list[tf.Tensor]) -> tf.keras.models.Model:
+        """ Create the model's structure.
+
+        Parameters
+        ----------
+        inputs: list
+            A list of input tensors for the model. This will be a list of 2 tensors of
+            shape :attr:`input_shape`, the first for side "a", the second for side "b".
+
+        Returns
+        -------
+        :class:`keras.models.Model`
+            The generated model
+        """
+        # Create sub-Models
+        encoders = self._build_encoders(inputs)
+        inters = self._build_fully_connected(encoders)
+        g_blocks = self._build_g_blocks(inters)
+        decoders = self._build_decoders(g_blocks)
+
+        # Create Autoencoder
+        outputs = [decoders["a"], decoders["b"]]
+        autoencoder = keras.models.Model(inputs, outputs, name=self.model_name)
+        return autoencoder
+
+    def _build_encoders(self, inputs: list[tf.Tensor]) -> dict[str, tf.keras.models.Model]:
+        """ Build the encoders for Phaze-A
+
+        Parameters
+        ----------
+        inputs: list
+            A list of input tensors for the model. This will be a list of 2 tensors of
+            shape :attr:`input_shape`, the first for side "a", the second for side "b".
+
+        Returns
+        -------
+        dict
+            side as key ('a' or 'b'), encoder for side as value
+        """
+        encoder = Encoder(self.input_shape, self.config)()
+        retval = {"a": encoder(inputs[0]), "b": encoder(inputs[1])}
+        logger.debug("Encoders: %s", retval)
+        return retval
+
+    def _build_fully_connected(
+            self,
+            inputs: dict[str, tf.keras.models.Model]) -> dict[str, list[tf.keras.models.Model]]:
+        """ Build the fully connected layers for Phaze-A
+
+        Parameters
+        ----------
+        inputs: dict
+            The compiled encoder models that act as inputs to the fully connected layers
+
+        Returns
+        -------
+        dict
+            side as key ('a' or 'b'), fully connected model for side as value
+        """
+        input_shapes = K.int_shape(inputs["a"])[1:]
+
+        if self.config["split_fc"]:
+            fc_a = FullyConnected("a", input_shapes, self.config)()
+            inter_a = [fc_a(inputs["a"])]
+            inter_b = [FullyConnected("b", input_shapes, self.config)()(inputs["b"])]
+        else:
+            fc_both = FullyConnected("both", input_shapes, self.config)()
+            inter_a = [fc_both(inputs["a"])]
+            inter_b = [fc_both(inputs["b"])]
+
+        if self.config["shared_fc"]:
+            if self.config["shared_fc"] == "full":
+                fc_shared = FullyConnected("shared", input_shapes, self.config)()
+            elif self.config["split_fc"]:
+                fc_shared = fc_a
+            else:
+                fc_shared = fc_both
+            inter_a = [kl.Concatenate(name="inter_a")([inter_a[0], fc_shared(inputs["a"])])]
+            inter_b = [kl.Concatenate(name="inter_b")([inter_b[0], fc_shared(inputs["b"])])]
+
+        if self.config["enable_gblock"]:
+            fc_gblock = FullyConnected("gblock", input_shapes, self.config)()
+            inter_a.append(fc_gblock(inputs["a"]))
+            inter_b.append(fc_gblock(inputs["b"]))
+
+        retval = {"a": inter_a, "b": inter_b}
+        logger.debug("Fully Connected: %s", retval)
+        return retval
+
+    def _build_g_blocks(
+                self,
+                inputs: dict[str, list[tf.keras.models.Model]]
+            ) -> dict[str, list[tf.keras.models.Model] | tf.keras.models.Model]:
+        """ Build the g-block layers for Phaze-A.
+
+        If a g-block has not been selected for this model, then the original `inters` models are
+        returned for passing straight to the decoder
+
+        Parameters
+        ----------
+        inputs: dict
+            The compiled inter models that act as inputs to the g_blocks
+
+        Returns
+        -------
+        dict
+            side as key ('a' or 'b'), g-block model for side as value. If g-block has been disabled
+            then the values will be the fully connected layers
+        """
+        if not self.config["enable_gblock"]:
+            logger.debug("No G-Block selected, returning Inters: %s", inputs)
+            return inputs
+
+        input_shapes = [K.int_shape(inter)[1:] for inter in inputs["a"]]
+        if self.config["split_gblock"]:
+            retval = {"a": GBlock("a", input_shapes, self.config)()(inputs["a"]),
+                      "b": GBlock("b", input_shapes, self.config)()(inputs["b"])}
+        else:
+            g_block = GBlock("both", input_shapes, self.config)()
+            retval = {"a": g_block((inputs["a"])), "b": g_block((inputs["b"]))}
+
+        logger.debug("G-Blocks: %s", retval)
+        return retval
+
+    def _build_decoders(self,
+                        inputs: dict[str, list[tf.keras.models.Model] | tf.keras.models.Model]
+                        ) -> dict[str, tf.keras.models.Model]:
+        """ Build the encoders for Phaze-A
+
+        Parameters
+        ----------
+        inputs: dict
+            A dict of inputs to the decoder. This will either be g-block output (if g-block is
+            enabled) or fully connected layers output (if g-block is disabled).
+
+        Returns
+        -------
+        dict
+            side as key ('a' or 'b'), decoder for side as value
+        """
+        input_ = inputs["a"]
+        # If input is inters, shapes will be a list.
+        # There will only ever be 1 input. For inters: either inter out, or concatenate of inters
+        # For g-block, this only ever has one output
+        input_ = input_[0] if isinstance(input_, list) else input_
+
+        # If learning a mask and upscales have been placed into FC layer, then the mask will also
+        # come as an input
+        if self.config["learn_mask"] and self.config["dec_upscales_in_fc"]:
+            input_ = input_[0]
+
+        input_shape = K.int_shape(input_)[1:]
+
+        if self.config["split_decoders"]:
+            retval = {"a": Decoder("a", input_shape, self.config)()(inputs["a"]),
+                      "b": Decoder("b", input_shape, self.config)()(inputs["b"])}
+        else:
+            decoder = Decoder("both", input_shape, self.config)()
+            retval = {"a": decoder(inputs["a"]), "b": decoder(inputs["b"])}
+
+        logger.debug("Decoders: %s", retval)
+        return retval
+
+
+def _bottleneck(inputs: tf.Tensor, bottleneck: str, size: int, normalization: str) -> tf.Tensor:
+    """ The bottleneck fully connected layer. Can be called from Encoder or FullyConnected layers.
+
+    Parameters
+    ----------
+    inputs: tensor
+        The input to the bottleneck layer
+    bottleneck: str or ``None``
+        The type of layer to use for the bottleneck. ``None`` to not use a bottleneck
+    size: int
+        The number of nodes for the dense layer (if selected)
+    normalization: str
+        The normalization method to use prior to the bottleneck layer
+
+    Returns
+    -------
+    tensor
+        The output from the bottleneck
+    """
+    norms = {"layer": kl.LayerNormalization,
+             "rms": RMSNormalization,
+             "instance": InstanceNormalization}
+    bottlenecks = {"average_pooling": kl.GlobalAveragePooling2D(),
+                   "dense": kl.Dense(size),
+                   "max_pooling": kl.GlobalMaxPooling2D()}
+    var_x = inputs
+    if normalization:
+        var_x = norms[normalization]()(var_x)
+    if bottleneck == "dense" and K.ndim(var_x) > 2:  # Flatten non-1D inputs for dense
+        var_x = kl.Flatten()(var_x)
+    if bottleneck != "flatten":
+        var_x = bottlenecks[bottleneck](var_x)
+    if K.ndim(var_x) > 2:
+        # Flatten prior to fc layers
+        var_x = kl.Flatten()(var_x)
+    return var_x
+
+
+def _get_upscale_layer(method: T.Literal["resize_images", "subpixel", "upscale_dny",
+                                         "upscale_fast", "upscale_hybrid", "upsample2d"],
+                       filters: int,
+                       activation: str | None = None,
+                       upsamples: int | None = None,
+                       interpolation: str | None = None) -> tf.keras.layers.Layer:
+    """ Obtain an instance of the requested upscale method.
+
+    Parameters
+    ----------
+    method: str
+        The user selected upscale method to use. One of `"resize_images"`, `"subpixel"`,
+        `"upscale_dny"`, `"upscale_fast"`, `"upscale_hybrid"`, `"upsample2d"`
+    filters: int
+        The number of filters to use in the upscale layer
+    activation: str, optional
+        The activation function to use in the upscale layer. ``None`` to use no activation.
+        Default: ``None``
+    upsamples: int, optional
+        Only used for UpSampling2D. If provided, then this is passed to the layer as the ``size``
+        parameter. Default: ``None``
+    interpolation: str, optional
+        Only used for UpSampling2D. If provided, then this is passed to the layer as the
+        ``interpolation`` parameter. Default: ``None``
+
+    Returns
+    -------
+    :class:`keras.layers.Layer`
+        The selected configured upscale layer
+    """
+    if method == "upsample2d":
+        kwargs: dict[str, str | int] = {}
+        if upsamples:
+            kwargs["size"] = upsamples
+        if interpolation:
+            kwargs["interpolation"] = interpolation
+        return kl.UpSampling2D(**kwargs)
+    if method == "subpixel":
+        return UpscaleBlock(filters, activation=activation)
+    if method == "upscale_fast":
+        return Upscale2xBlock(filters, activation=activation, fast=True)
+    if method == "upscale_hybrid":
+        return Upscale2xBlock(filters, activation=activation, fast=False)
+    if method == "upscale_dny":
+        return UpscaleDNYBlock(filters, activation=activation)
+    return UpscaleResizeImagesBlock(filters, activation=activation)
+
+
+def _get_curve(start_y: int,
+               end_y: int,
+               num_points: int,
+               scale: float,
+               mode: T.Literal["full", "cap_max", "cap_min"] = "full") -> list[int]:
+    """ Obtain a curve.
+
+    For the given start and end y values, return the y co-ordinates of a curve for the given
+    number of points. The points are rounded down to the nearest 8.
+
+    Parameters
+    ----------
+    start_y: int
+        The y co-ordinate for the starting point of the curve
+    end_y: int
+        The y co-ordinate for the end point of the curve
+    num_points: int
+        The number of data points to plot on the x-axis
+    scale: float
+        The scale of the curve (from -.99 to 0.99)
+    slope_mode: str, optional
+        The method to generate the curve. One of `"full"`, `"cap_max"` or `"cap_min"`. `"full"`
+        mode generates a curve from the `"start_y"` to the `"end_y"` values. `"cap_max"` pads the
+        earlier points with the `"start_y"` value before filling out the remaining points at a
+        fixed divider to the `"end_y"` value. `"cap_min"` starts at the `"start_y" filling points
+        at a fixed divider until the `"end_y"` value is reached and pads the remaining points with
+        the `"end_y"` value. Default: `"full"`
+
+    Returns
+    -------
+    list
+        List of ints of points for the given curve
+     """
+    scale = min(.99, max(-.99, scale))
+    logger.debug("Obtaining curve: (start_y: %s, end_y: %s, num_points: %s, scale: %s, mode: %s)",
+                 start_y, end_y, num_points, scale, mode)
+    if mode == "full":
+        x_axis = np.linspace(0., 1., num=num_points)
+        y_axis = (x_axis - x_axis * scale) / (scale - abs(x_axis) * 2 * scale + 1)
+        y_axis = y_axis * (end_y - start_y) + start_y
+        retval = [int((y // 8) * 8) for y in y_axis]
+    else:
+        y_axis = [start_y]
+        scale = 1. - abs(scale)
+        for _ in range(num_points - 1):
+            current_value = max(end_y, int(((y_axis[-1] * scale) // 8) * 8))
+            y_axis.append(current_value)
+            if current_value == end_y:
+                break
+        pad = [start_y if mode == "cap_max" else end_y for _ in range(num_points - len(y_axis))]
+        retval = pad + y_axis if mode == "cap_max" else y_axis + pad
+    logger.debug("Returning curve: %s", retval)
+    return retval
+
+
+def _scale_dim(target_resolution: int, original_dim: int) -> int:
+    """ Scale a given `original_dim` so that it is a factor of the target resolution.
+
+    Parameters
+    ----------
+    target_resolution: int
+        The output resolution that is being targetted
+    original_dim: int
+        The dimension that needs to be checked for compatibility for upscaling to the
+        target resolution
+
+    Returns
+    -------
+    int
+        The highest dimension below or equal to `original_dim` that is a factor of the
+    target resolution.
+    """
+    new_dim = target_resolution
+    while new_dim > original_dim:
+        next_dim = new_dim / 2
+        if not next_dim.is_integer():
+            break
+        new_dim = int(next_dim)
+    logger.debug("target_resolution: %s, original_dim: %s, new_dim: %s",
+                 target_resolution, original_dim, new_dim)
+    return new_dim
+
+
+class Encoder():  # pylint:disable=too-few-public-methods
+    """ Encoder. Uses one of pre-existing Keras/Faceswap models or custom encoder.
+
+    Parameters
+    ----------
+    input_shape: tuple
+        The shape tuple for the input tensor
+    config: dict
+        The model configuration options
+    """
+    def __init__(self, input_shape: tuple[int, int, int], config: dict) -> None:
+        self.input_shape = input_shape
+        self._config = config
+        self._input_shape = input_shape
+
+    @property
+    def _model_kwargs(self) -> dict[str, dict[str, str | bool]]:
+        """ dict: Configuration option for architecture mapped to optional kwargs. """
+        return {"mobilenet": {"alpha": self._config["mobilenet_width"],
+                              "depth_multiplier": self._config["mobilenet_depth"],
+                              "dropout": self._config["mobilenet_dropout"]},
+                "mobilenet_v2": {"alpha": self._config["mobilenet_width"]},
+                "mobilenet_v3": {"alpha": self._config["mobilenet_width"],
+                                 "minimalist": self._config["mobilenet_minimalistic"],
+                                 "include_preprocessing": False}}
+
+    @property
+    def _selected_model(self) -> tuple[_EncoderInfo, dict]:
+        """ tuple(dict, :class:`_EncoderInfo`): The selected encoder model and it's associated
+        keyword arguments """
+        arch = self._config["enc_architecture"]
+        model = _MODEL_MAPPING[arch]
+        kwargs = self._model_kwargs.get(arch, {})
+        if arch.startswith("efficientnet_v2"):
+            kwargs["include_preprocessing"] = False
+        return model, kwargs
+
+    def __call__(self) -> tf.keras.models.Model:
+        """ Create the Phaze-A Encoder Model.
+
+        Returns
+        -------
+        :class:`keras.models.Model`
+            The selected Encoder Model
+        """
+        input_ = kl.Input(shape=self._input_shape)
+        var_x = input_
+
+        scaling = self._selected_model[0].scaling
+
+        if scaling:
+            #  Some models expect different scaling.
+            logger.debug("Scaling to %s for '%s'", scaling, self._config["enc_architecture"])
+            if scaling == (0, 255):
+                # models expecting inputs from 0 to 255.
+                var_x = var_x * 255.
+            if scaling == (-1, 1):
+                # models expecting inputs from -1 to 1.
+                var_x = var_x * 2.
+                var_x = var_x - 1.0
+
+        if (self._config["enc_architecture"].startswith("efficientnet_b")
+                and self._config["mixed_precision"]):
+            # There is a bug in EfficientNet pre-processing where the normalized mean for the
+            # imagenet rgb values are not cast to float16 when mixed precision is enabled.
+            # We monkeypatch in a cast constant until the issue is resolved
+            # TODO revert if/when applying Imagenet Normalization works with mixed precision
+            # confirmed bugged: TF2.10
+            logger.debug("Patching efficientnet.IMAGENET_STDDEV_RGB to float16 constant")
+            from keras.applications import efficientnet  # pylint:disable=import-outside-toplevel
+            setattr(efficientnet,
+                    "IMAGENET_STDDEV_RGB",
+                    K.constant(efficientnet.IMAGENET_STDDEV_RGB, dtype="float16"))
+
+        var_x = self._get_encoder_model()(var_x)
+
+        if self._config["bottleneck_in_encoder"]:
+            var_x = _bottleneck(var_x,
+                                self._config["bottleneck_type"],
+                                self._config["bottleneck_size"],
+                                self._config["bottleneck_norm"])
+
+        return keras.models.Model(input_, var_x, name="encoder")
+
+    def _get_encoder_model(self) -> tf.keras.models.Model:
+        """ Return the model defined by the selected architecture.
+
+        Returns
+        -------
+        :class:`keras.Model`
+            The selected keras model for the chosen encoder architecture
+        """
+        model, kwargs = self._selected_model
+        if model.keras_name and self._config["enc_architecture"].startswith("clipv_"):
+            assert model.keras_name in T.get_args(TypeModelsViT)
+            kwargs["input_shape"] = self._input_shape
+            kwargs["load_weights"] = self._config["enc_load_weights"]
+            retval = ViT(T.cast(TypeModelsViT, model.keras_name),
+                         input_size=self._input_shape[0],
+                         load_weights=self._config["enc_load_weights"])()
+        elif model.keras_name:
+            kwargs["input_shape"] = self._input_shape
+            kwargs["include_top"] = False
+            kwargs["weights"] = "imagenet" if self._config["enc_load_weights"] else None
+            retval = getattr(kapp, model.keras_name)(**kwargs)
+        else:
+            retval = _EncoderFaceswap(self._config)
+        return retval
+
+
+class _EncoderFaceswap():  # pylint:disable=too-few-public-methods
+    """ A configurable standard Faceswap encoder based off Original model.
+
+    Parameters
+    ----------
+    config: dict
+        The model configuration options
+    """
+    def __init__(self, config: dict) -> None:
+        self._config = config
+        self._type = self._config["enc_architecture"]
+        self._depth = config[f"{self._type}_depth"]
+        self._min_filters = config["fs_original_min_filters"]
+        self._max_filters = config["fs_original_max_filters"]
+        self._is_alt = config["fs_original_use_alt"]
+        self._relu_alpha = 0.2 if self._is_alt else 0.1
+        self._kernel_size = 3 if self._is_alt else 5
+        self._strides = 1 if self._is_alt else 2
+
+    def __call__(self, inputs: tf.Tensor) -> tf.Tensor:
+        """ Call the original Faceswap Encoder
+
+        Parameters
+        ----------
+        inputs: tensor
+            The input tensor to the Faceswap Encoder
+
+        Returns
+        -------
+        tensor
+            The output tensor from the Faceswap Encoder
+        """
+        var_x = inputs
+        filters = self._config["fs_original_min_filters"]
+
+        if self._is_alt:
+            var_x = Conv2DBlock(filters,
+                                kernel_size=1,
+                                strides=self._strides,
+                                relu_alpha=self._relu_alpha)(var_x)
+
+        for i in range(self._depth):
+            name = f"fs_{'dny_' if self._is_alt else ''}enc"
+            var_x = Conv2DBlock(filters,
+                                kernel_size=self._kernel_size,
+                                strides=self._strides,
+                                relu_alpha=self._relu_alpha,
+                                name=f"{name}_convblk_{i}")(var_x)
+            filters = min(self._config["fs_original_max_filters"], filters * 2)
+            if self._is_alt and i == self._depth - 1:
+                var_x = Conv2DBlock(filters,
+                                    kernel_size=4,
+                                    strides=self._strides,
+                                    padding="valid",
+                                    relu_alpha=self._relu_alpha,
+                                    name=f"{name}_convblk_{i}_1")(var_x)
+            elif self._is_alt:
+                var_x = Conv2DBlock(filters,
+                                    kernel_size=self._kernel_size,
+                                    strides=self._strides,
+                                    relu_alpha=self._relu_alpha,
+                                    name=f"{name}_convblk_{i}_1")(var_x)
+                var_x = kl.MaxPool2D(2, name=f"{name}_pool_{i}")(var_x)
+        return var_x
+
+
+class FullyConnected():  # pylint:disable=too-few-public-methods
+    """ Intermediate Fully Connected layers for Phaze-A Model.
+
+    Parameters
+    ----------
+    side: ["a", "b", "both", "gblock", "shared"]
+        The side of the model that the fully connected layers belong to. Used for naming
+    input_shape: tuple
+        The input shape for the fully connected layers
+    config: dict
+        The user configuration dictionary
+    """
+    def __init__(self,
+                 side: T.Literal["a", "b", "both", "gblock", "shared"],
+                 input_shape: tuple,
+                 config: dict) -> None:
+        logger.debug("Initializing: %s (side: %s, input_shape: %s)",
+                     self.__class__.__name__, side, input_shape)
+        self._side = side
+        self._input_shape = input_shape
+        self._config = config
+        self._final_dims = self._config["fc_dimensions"] * (self._config["fc_upsamples"] + 1)
+        self._prefix = "fc_gblock" if self._side == "gblock" else "fc"
+
+        logger.debug("Initialized: %s (side: %s, min_nodes: %s, max_nodes: %s)",
+                     self.__class__.__name__, self._side, self._min_nodes, self._max_nodes)
+
+    @property
+    def _min_nodes(self) -> int:
+        """ int: The number of nodes for the first Dense. For non g-block layers this will be the
+        given minimum filters multiplied by the dimensions squared. For g-block layers, this is the
+        given value """
+        if self._side == "gblock":
+            return self._config["fc_gblock_min_nodes"]
+        retval = self._scale_filters(self._config["fc_min_filters"])
+        retval = int(retval * self._config["fc_dimensions"] ** 2)
+        return retval
+
+    @property
+    def _max_nodes(self) -> int:
+        """ int: The number of nodes for the final Dense. For non g-block layers this will be the
+        given maximum filters multiplied by the dimensions squared. This number will be scaled down
+        if the final shape can not be mapped to the requested output size.
+
+        For g-block layers, this is the given config value.
+        """
+        if self._side == "gblock":
+            return self._config["fc_gblock_max_nodes"]
+        retval = self._scale_filters(self._config["fc_max_filters"])
+        retval = int(retval * self._config["fc_dimensions"] ** 2)
+        return retval
+
+    def _scale_filters(self, original_filters: int) -> int:
+        """ Scale the filters to be compatible with the model's selected output size.
+
+        Parameters
+        ----------
+        original_filters: int
+            The original user selected number of filters
+
+        Returns
+        -------
+        int
+            The number of filters scaled down for output size
+        """
+        scaled_dim = _scale_dim(self._config["output_size"], self._final_dims)
+        if scaled_dim == self._final_dims:
+            logger.debug("filters don't require scaling. Returning: %s", original_filters)
+            return original_filters
+
+        flat = self._final_dims ** 2 * original_filters
+        modifier = self._final_dims ** 2 * scaled_dim ** 2
+        retval = int((flat // modifier) * modifier)
+        retval = int(retval / self._final_dims ** 2)
+        logger.debug("original_filters: %s, scaled_filters: %s", original_filters, retval)
+        return retval
+
+    def _do_upsampling(self, inputs: tf.Tensor) -> tf.Tensor:
+        """ Perform the upsampling at the end of the fully connected layers.
+
+        Parameters
+        ----------
+        inputs: Tensor
+            The input to the upsample layers
+
+        Returns
+        -------
+        Tensor
+            The output from the upsample layers
+        """
+        upsample_filts = self._scale_filters(self._config["fc_upsample_filters"])
+        upsampler = self._config["fc_upsampler"].lower()
+        num_upsamples = self._config["fc_upsamples"]
+        var_x = inputs
+        if upsampler == "upsample2d" and num_upsamples > 1:
+            upscaler = _get_upscale_layer(upsampler,
+                                          upsample_filts,  # Not used but required
+                                          upsamples=2 ** num_upsamples,
+                                          interpolation="bilinear")
+            var_x = upscaler(var_x)
+        else:
+            for _ in range(num_upsamples):
+                upscaler = _get_upscale_layer(upsampler,
+                                              upsample_filts,
+                                              activation="leakyrelu")
+                var_x = upscaler(var_x)
+        if upsampler == "upsample2d":
+            var_x = kl.LeakyReLU(alpha=0.1)(var_x)
+        return var_x
+
+    def __call__(self) -> tf.keras.models.Model:
+        """ Call the intermediate layer.
+
+        Returns
+        -------
+        :class:`keras.models.Model`
+            The Fully connected model
+        """
+        input_ = kl.Input(shape=self._input_shape)
+        var_x = input_
+
+        node_curve = _get_curve(self._min_nodes,
+                                self._max_nodes,
+                                self._config[f"{self._prefix}_depth"],
+                                self._config[f"{self._prefix}_filter_slope"])
+
+        if not self._config["bottleneck_in_encoder"]:
+            var_x = _bottleneck(var_x,
+                                self._config["bottleneck_type"],
+                                self._config["bottleneck_size"],
+                                self._config["bottleneck_norm"])
+
+        dropout = f"{self._prefix}_dropout"
+        for idx, nodes in enumerate(node_curve):
+            var_x = kl.Dropout(self._config[dropout], name=f"{dropout}_{idx + 1}")(var_x)
+            var_x = kl.Dense(nodes)(var_x)
+
+        if self._side != "gblock":
+            dim = self._config["fc_dimensions"]
+            var_x = kl.Reshape((dim, dim, int(self._max_nodes / (dim ** 2))))(var_x)
+            var_x = self._do_upsampling(var_x)
+
+            num_upscales = self._config["dec_upscales_in_fc"]
+            if num_upscales:
+                var_x = UpscaleBlocks(self._side,
+                                      self._config,
+                                      layer_indicies=(0, num_upscales))(var_x)
+
+        return keras.models.Model(input_, var_x, name=f"fc_{self._side}")
+
+
+class UpscaleBlocks():  # pylint:disable=too-few-public-methods
+    """ Obtain a block of upscalers.
+
+    This class exists outside of the :class:`Decoder` model, as it is possible to place some of
+    the upscalers at the end of the Fully Connected Layers, so the upscale chain needs to be able
+    to be calculated by both the Fully Connected Layers and by the Decoder if required.
+
+    For this reason, the Upscale Filter list is created as a class attribute of the
+    :class:`UpscaleBlocks` layers for reference by either the Decoder or Fully Connected models
+
+    Parameters
+    ----------
+    side: ["a", "b", "both", "shared"]
+        The side of the model that the Decoder belongs to. Used for naming
+    config: dict
+        The user configuration dictionary
+    layer_indices: tuple, optional
+        The tuple indicies indicating the starting layer index and the ending layer index to
+        generate upscales for. Used for when splitting upscales between the Fully Connected Layers
+        and the Decoder. ``None`` will generate the full Upscale chain. An end index of -1 will
+        generate the layers from the starting index to the final upscale. Default: ``None``
+    """
+    _filters: list[int] = []
+
+    def __init__(self,
+                 side: T.Literal["a", "b", "both", "shared"],
+                 config: dict,
+                 layer_indicies: tuple[int, int] | None = None) -> None:
+        logger.debug("Initializing: %s (side: %s, layer_indicies: %s)",
+                     self.__class__.__name__, side, layer_indicies)
+        self._side = side
+        self._config = config
+        self._is_dny = self._config["dec_upscale_method"].lower() == "upscale_dny"
+        self._layer_indicies = layer_indicies
+        logger.debug("Initialized: %s", self.__class__.__name__,)
+
+    def _reshape_for_output(self, inputs: tf.Tensor) -> tf.Tensor:
+        """ Reshape the input for arbitrary output sizes.
+
+        The number of filters in the input will have been scaled to the model output size allowing
+        us to scale the dimensions to the requested output size.
+
+        Parameters
+        ----------
+        inputs: tensor
+            The tensor that is to be reshaped
+
+        Returns
+        -------
+        tensor
+            The tensor shaped correctly to upscale to output size
+        """
+        var_x = inputs
+        old_dim = K.int_shape(inputs)[1]
+        new_dim = _scale_dim(self._config["output_size"], old_dim)
+        if new_dim != old_dim:
+            old_shape = K.int_shape(inputs)[1:]
+            new_shape = (new_dim, new_dim, np.prod(old_shape) // new_dim ** 2)
+            logger.debug("Reshaping tensor from %s to %s for output size %s",
+                         K.int_shape(inputs)[1:], new_shape, self._config["output_size"])
+            var_x = kl.Reshape(new_shape)(var_x)
+        return var_x
+
+    def _upscale_block(self,
+                       inputs: tf.Tensor,
+                       filters: int,
+                       skip_residual: bool = False,
+                       is_mask: bool = False) -> tf.Tensor:
+        """ Upscale block for Phaze-A Decoder.
+
+        Uses requested upscale method, adds requested regularization and activation function.
+
+        Parameters
+        ----------
+        inputs: tensor
+            The input tensor for the upscale block
+        filters: int
+            The number of filters to use for the upscale
+        skip_residual: bool, optional
+            ``True`` if a residual block should not be placed in the upscale block, otherwise
+            ``False``. Default ``False``
+        is_mask: bool, optional
+            ``True`` if the input is a mask. ``False`` if the input is a face. Default: ``False``
+
+        Returns
+        -------
+        tensor
+            The output tensor from the upscale block
+        """
+        upscaler = _get_upscale_layer(self._config["dec_upscale_method"].lower(),
+                                      filters,
+                                      activation="leakyrelu",
+                                      upsamples=2,
+                                      interpolation="bilinear")
+
+        var_x = upscaler(inputs)
+        if not is_mask and self._config["dec_gaussian"]:
+            var_x = kl.GaussianNoise(1.0)(var_x)
+        if not is_mask and self._config["dec_res_blocks"] and not skip_residual:
+            var_x = self._normalization(var_x)
+            var_x = kl.LeakyReLU(alpha=0.2)(var_x)
+            for _ in range(self._config["dec_res_blocks"]):
+                var_x = ResidualBlock(filters)(var_x)
+        else:
+            var_x = self._normalization(var_x)
+            if not self._is_dny:
+                var_x = kl.LeakyReLU(alpha=0.1)(var_x)
+        return var_x
+
+    def _normalization(self, inputs: tf.Tensor) -> tf.Tensor:
+        """ Add a normalization layer if requested.
+
+        Parameters
+        ----------
+        inputs: tensor
+            The input tensor to apply normalization to.
+
+        Returns
+        --------
+        tensor
+            The tensor with any normalization applied
+        """
+        if not self._config["dec_norm"]:
+            return inputs
+        norms = {"batch": kl.BatchNormalization,
+                 "group": GroupNormalization,
+                 "instance": InstanceNormalization,
+                 "layer": kl.LayerNormalization,
+                 "rms": RMSNormalization}
+        return norms[self._config["dec_norm"]]()(inputs)
+
+    def _dny_entry(self, inputs: tf.Tensor) -> tf.Tensor:
+        """ Entry convolutions for using the upscale_dny method.
+
+        Parameters
+        ----------
+        inputs: Tensor
+            The inputs to the dny entry block
+
+        Returns
+        -------
+        Tensor
+            The output from the dny entry block
+        """
+        var_x = Conv2DBlock(self._config["dec_max_filters"],
+                            kernel_size=4,
+                            strides=1,
+                            padding="same",
+                            relu_alpha=0.2)(inputs)
+        var_x = Conv2DBlock(self._config["dec_max_filters"],
+                            kernel_size=3,
+                            strides=1,
+                            padding="same",
+                            relu_alpha=0.2)(var_x)
+        return var_x
+
+    def __call__(self, inputs: tf.Tensor | list[tf.Tensor]) -> tf.Tensor | list[tf.Tensor]:
+        """ Upscale Network.
+
+        Parameters
+        inputs: Tensor or list of tensors
+            Input tensor(s) to upscale block. This will be a single tensor if learn mask is not
+            selected or if this is the first call to the upscale blocks. If learn mask is selected
+            and this is not the first call to upscale blocks, then this will be a list of the face
+            and mask tensors.
+
+        Returns
+        -------
+         Tensor or list of tensors
+            The output of encoder blocks. Either a single tensor (if learn mask is not enabled) or
+            list of tensors (if learn mask is enabled)
+        """
+        start_idx, end_idx = (0, None) if self._layer_indicies is None else self._layer_indicies
+        end_idx = None if end_idx == -1 else end_idx
+
+        if self._config["learn_mask"] and start_idx == 0:
+            # Mask needs to be created
+            var_x = inputs
+            var_y = inputs
+        elif self._config["learn_mask"]:
+            # Mask has already been created and is an input to upscale blocks
+            var_x, var_y = inputs
+        else:
+            # No mask required
+            var_x = inputs
+
+        if start_idx == 0:
+            var_x = self._reshape_for_output(var_x)
+
+            if self._config["learn_mask"]:
+                var_y = self._reshape_for_output(var_y)
+
+            if self._is_dny:
+                var_x = self._dny_entry(var_x)
+            if self._is_dny and self._config["learn_mask"]:
+                var_y = self._dny_entry(var_y)
+
+        # De-convolve
+        if not self._filters:
+            upscales = int(np.log2(self._config["output_size"] / K.int_shape(var_x)[1]))
+            self._filters.extend(_get_curve(self._config["dec_max_filters"],
+                                            self._config["dec_min_filters"],
+                                            upscales,
+                                            self._config["dec_filter_slope"],
+                                            mode=self._config["dec_slope_mode"]))
+            logger.debug("Generated class filters: %s", self._filters)
+
+        filters = self._filters[start_idx: end_idx]
+
+        for idx, filts in enumerate(filters):
+            skip_res = idx == len(filters) - 1 and self._config["dec_skip_last_residual"]
+            var_x = self._upscale_block(var_x, filts, skip_residual=skip_res)
+            if self._config["learn_mask"]:
+                var_y = self._upscale_block(var_y, filts, is_mask=True)
+        retval = [var_x, var_y] if self._config["learn_mask"] else var_x
+        return retval
+
+
+class GBlock():  # pylint:disable=too-few-public-methods
+    """ G-Block model, borrowing from Adain StyleGAN.
+
+    Parameters
+    ----------
+    side: ["a", "b", "both"]
+        The side of the model that the fully connected layers belong to. Used for naming
+    input_shapes: list or tuple
+        The shape tuples for the input to the G-Block. The first item is the input from each side's
+        fully connected model, the second item is the input shape from the combined fully connected
+        model.
+    config: dict
+        The user configuration dictionary
+    """
+    def __init__(self,
+                 side: T.Literal["a", "b", "both"],
+                 input_shapes: list | tuple,
+                 config: dict) -> None:
+        logger.debug("Initializing: %s (side: %s, input_shapes: %s)",
+                     self.__class__.__name__, side, input_shapes)
+        self._side = side
+        self._config = config
+        self._inputs = [kl.Input(shape=shape) for shape in input_shapes]
+        self._dense_nodes = 512
+        self._dense_recursions = 3
+        logger.debug("Initialized: %s", self.__class__.__name__)
+
+    @classmethod
+    def _g_block(cls,
+                 inputs: tf.Tensor,
+                 style: tf.Tensor,
+                 filters: int,
+                 recursions: int = 2) -> tf.Tensor:
+        """ G_block adapted from ADAIN StyleGAN.
+
+        Parameters
+        ----------
+        inputs: tensor
+            The input tensor to the G-Block model
+        style: tensor
+            The input combined 'style' tensor to the G-Block model
+        filters: int
+            The number of filters to use for the G-Block Convolutional layers
+        recursions: int, optional
+            The number of recursive Convolutions to process. Default: `2`
+
+        Returns
+        -------
+        tensor
+            The output tensor from the G-Block model
+        """
+        var_x = inputs
+        for i in range(recursions):
+            styles = [kl.Reshape([1, 1, filters])(kl.Dense(filters)(style)) for _ in range(2)]
+            noise = kl.Conv2D(filters, 1, padding="same")(kl.GaussianNoise(1.0)(var_x))
+
+            if i == recursions - 1:
+                var_x = kl.Conv2D(filters, 3, padding="same")(var_x)
+
+            var_x = AdaInstanceNormalization(dtype="float32")([var_x, *styles])
+            var_x = kl.Add()([var_x, noise])
+            var_x = kl.LeakyReLU(0.2)(var_x)
+
+        return var_x
+
+    def __call__(self) -> tf.keras.models.Model:
+        """ G-Block Network.
+
+        Returns
+        -------
+        :class:`keras.models.Model`
+            The G-Block model
+        """
+        var_x, style = self._inputs
+        for i in range(self._dense_recursions):
+            style = kl.Dense(self._dense_nodes, kernel_initializer="he_normal")(style)
+            if i != self._dense_recursions - 1:  # Don't add leakyReLu to final output
+                style = kl.LeakyReLU(0.1)(style)
+
+        # Scale g_block filters to side dense
+        g_filts = K.int_shape(var_x)[-1]
+        var_x = Conv2D(g_filts, 3, strides=1, padding="same")(var_x)
+        var_x = kl.GaussianNoise(1.0)(var_x)
+        var_x = self._g_block(var_x, style, g_filts)
+        return keras.models.Model(self._inputs, var_x, name=f"g_block_{self._side}")
+
+
+class Decoder():  # pylint:disable=too-few-public-methods
+    """ Decoder Network.
+
+    Parameters
+    ----------
+    side: ["a", "b", "both"]
+        The side of the model that the Decoder belongs to. Used for naming
+    input_shape: tuple
+        The shape tuple for the input to the decoder.
+    config: dict
+        The user configuration dictionary
+    """
+    def __init__(self,
+                 side: T.Literal["a", "b", "both"],
+                 input_shape: tuple[int, int, int],
+                 config: dict) -> None:
+        logger.debug("Initializing: %s (side: %s, input_shape: %s)",
+                     self.__class__.__name__, side, input_shape)
+        self._side = side
+        self._input_shape = input_shape
+        self._config = config
+        logger.debug("Initialized: %s", self.__class__.__name__,)
+
+    def __call__(self) -> tf.keras.models.Model:
+        """ Decoder Network.
+
+        Returns
+        -------
+        :class:`keras.models.Model`
+            The Decoder model
+        """
+        inputs = kl.Input(shape=self._input_shape)
+
+        num_ups_in_fc = self._config["dec_upscales_in_fc"]
+
+        if self._config["learn_mask"] and num_ups_in_fc:
+            # Mask has already been created in FC and is an output of that model
+            inputs = [inputs, kl.Input(shape=self._input_shape)]
+
+        indicies = None if not num_ups_in_fc else (num_ups_in_fc, -1)
+        upscales = UpscaleBlocks(self._side,
+                                 self._config,
+                                 layer_indicies=indicies)(inputs)
+
+        if self._config["learn_mask"]:
+            var_x, var_y = upscales
+        else:
+            var_x = upscales
+
+        outputs = [Conv2DOutput(3, self._config["dec_output_kernel"], name="face_out")(var_x)]
+        if self._config["learn_mask"]:
+            outputs.append(Conv2DOutput(1,
+                                        self._config["dec_output_kernel"],
+                                        name="mask_out")(var_y))
+
+        return keras.models.Model(inputs, outputs=outputs, name=f"decoder_{self._side}")
+
+
+# Alias the custom class to the expected name for the plugin loader
+Model = ModelCustom

--- a/plugins/train/model/phaze_a_custom_defaults.py
+++ b/plugins/train/model/phaze_a_custom_defaults.py
@@ -1,0 +1,731 @@
+#!/usr/bin/env python3
+"""
+    The default options for the faceswap Phaze-A Custom Model plugin.
+
+    Defaults files should be named <plugin_name>_defaults.py
+    Any items placed into this file will automatically get added to the relevant config .ini files
+    within the faceswap/config folder.
+
+    The following variables should be defined:
+        "_HELPTEXT: A string describing what this plugin does
+        "_DEFAULTS: A dictionary containing the options, defaults and meta information. The
+               "   dictionary should be defined as:
+               "       {<option_name>: {<metadata>}}
+
+               "   <option_name> should always be lower text.
+               "   <metadata> dictionary requirements are listed below.
+
+    The following keys are expected for the _DEFAULTS <metadata> dict:
+        "datatype:  [required] A python type class. This limits the type of data that can be
+               "   provided in the .ini file and ensures that the value is returned in the
+               "   correct type to faceswap. Valid data types are: <class 'int'>, <class 'float'>,
+               "   <class 'str'>, <class 'bool'>.
+        "default:   [required] The default value for this option.
+        "info:      [required] A string describing what this option does.
+        "choices:   [optional] If this option's datatype is of <class 'str'> then valid
+               "   selections can be defined here. This validates the option and also enables
+               "   a combobox / radio option in the GUI.
+        "gui_radio: [optional] If <choices> are defined, this indicates that the GUI should use
+               "   radio buttons rather than a combobox to display this option.
+        "min_max:   [partial] For <class 'int'> and <class 'float'> data types this is required
+               "   otherwise it is ignored. Should be a tuple of min and max accepted values.
+               "   This is used for controlling the GUI slider range. Values are not enforced.
+        "rounding:  [partial] For <class 'int'> and <class 'float'> data types this is
+               "   required otherwise it is ignored. Used for the GUI slider. For floats, this
+               "   is the number of decimal places to display. For ints this is the step size.
+        "fixed:     [optional] [train only]. Training configurations are fixed when the model is
+               "   created, and then reloaded from the state file. Marking an item as fixed=False
+               "   indicates that this value can be changed for existing models, and will override
+               "   the value saved in the state file with the updated value in config. If not
+               "   provided this will default to True.
+"""
+
+_HELPTEXT: str = (
+    "Phaze-A Custom Model by TorzDF, with thanks to BirbFakes.\n"
+    "Allows for the experimentation of various standard Networks as the encoder and takes "
+    "inspiration from Nvidia's StyleGAN for the Decoder. This custom variant exposes additional "
+    "upscalers, including the UpscaleDNY block. It is highly recommended to research to "
+    "understand the parameters better.")
+
+_ENCODERS: list[str] = sorted([
+    "clipv_vit-b-16", "clipv_vit-b-32", "clipv_vit-l-14", "clipv_vit-l-14-336px",
+    "clipv_farl-b-16-16", "clipv_farl-b-16-64",
+    "densenet121", "densenet169", "densenet201", "efficientnet_b0", "efficientnet_b1",
+    "efficientnet_b2", "efficientnet_b3", "efficientnet_b4", "efficientnet_b5", "efficientnet_b6",
+    "efficientnet_b7", "efficientnet_v2_b0", "efficientnet_v2_b1", "efficientnet_v2_b2",
+    "efficientnet_v2_b3", "efficientnet_v2_l", "efficientnet_v2_m", "efficientnet_v2_s",
+    "inception_resnet_v2", "inception_v3", "mobilenet", "mobilenet_v2", "mobilenet_v3_large",
+    "mobilenet_v3_small", "nasnet_large", "nasnet_mobile", "resnet50", "resnet50_v2", "resnet101",
+    "resnet101_v2", "resnet152", "resnet152_v2", "vgg16", "vgg19", "xception", "fs_original"])
+
+_DEFAULTS = {
+    # General
+    "output_size": {
+        "default": 128,
+        "info": (
+            "Resolution (in pixels) of the output image to generate.\n"
+            "BE AWARE Larger resolution will dramatically increase VRAM requirements."),
+        "datatype": int,
+        "rounding": 16,
+        "min_max": (64, 2048),
+        "group": "general",
+        "fixed": True},
+    "shared_fc": {
+        "default": "none",
+        "info": (
+            "Whether to create a shared fully connected layer. This layer will have the same "
+            "structure as the fully connected layers used for each side of the model. A shared "
+            "fully connected layer looks for patterns that are common to both sides. NB: "
+            "Enabling this option only makes sense if 'split fc' is selected."
+            "\n\tnone - Do not create a Fully Connected layer for shared data. (Original method)"
+            "\n\tfull - Create an exclusive Fully Connected layer for shared data. (IAE method)"
+            "\n\thalf - Use the 'fc_a' layer for shared data. This saves VRAM by re-using the "
+            "'A' side's fully connected model for the shared data. However, this will lead to "
+            "an 'unbalanced' model and can lead to more identity bleed (DFL method)"),
+        "datatype": str,
+        "choices": ["none", "full",  "upscale_dny", "half"],
+        "gui_radio": True,
+        "group": "general",
+        "fixed": True},
+    "enable_gblock": {
+        "default": True,
+        "info": (
+            "Whether to enable the G-Block. If enabled, this will create a shared fully "
+            "connected layer (configurable in the 'G-Block hidden layers' section) to look for "
+            "patterns in the combined data, before feeding a block prior to the decoder for "
+            "merging this shared and combined data."
+            "\n\tTrue - Use the G-Block in the Decoder. A combined fully connected layer will be "
+            "created to feed this block which can be configured below."
+            "\n\tFalse - Don't use the G-Block in the decoder. No combined fully connected layer "
+            "will be created."),
+        "datatype": bool,
+        "group": "general",
+        "fixed": True},
+    "split_fc": {
+        "default": True,
+        "info": (
+            "Whether to use a single shared Fully Connected layer or separate Fully Connected "
+            "layers for each side."
+            "\n\tTrue - Use separate Fully Connected layers for Face A and Face B. This is more "
+            "similar to the 'IAE' style of model."
+            "\n\tFalse - Use combined Fully Connected layers for both sides. This is more "
+            "similar to the original Faceswap architecture."),
+        "datatype": bool,
+        "group": "general",
+        "fixed": True},
+    "split_gblock": {
+        "default": False,
+        "info": (
+            "If the G-Block is enabled, Whether to use a single G-Block shared between both "
+            "sides, or whether to have a separate G-Block (one for each side). NB: The Fully "
+            "Connected layer that feeds the G-Block will always be shared."
+            "\n\tTrue - Use separate G-Blocks for Face A and Face B."
+            "\n\tFalse - Use a combined G-Block layers for both sides."),
+        "datatype": bool,
+        "group": "general",
+        "fixed": True},
+    "split_decoders": {
+        "default": False,
+        "info": (
+            "Whether to use a single decoder or split decoders."
+            "\n\tTrue - Use a separate decoder for Face A and Face B. This is more similar to "
+            "the original Faceswap architecture."
+            "\n\tFalse - Use a combined Decoder. This is more similar to 'IAE' style "
+            "architecture."),
+        "datatype": bool,
+        "group": "general",
+        "fixed": True},
+
+    # Encoder
+    "enc_architecture": {
+        "default": "fs_original",
+        "info": (
+            "The encoder architecture to use. See the relevant config sections for specific "
+            "architecture tweaking.\nNB: For keras based pre-built models, the global "
+            "initializers and padding options will be ignored for the selected encoder."
+            "\n\n\tCLIPv: This is an implementation of the Visual encoder from the CLIP "
+            "transformer. The ViT weights are trained on imagenet whilst the FaRL weights are "
+            "trained on face related tasks. All have a default input size of 224px except for "
+            "ViT-L-14-336px that has an input size of 336px. Ref: Learning Transferable Visual "
+            "Models From Natural Language Supervision (2021): https://arxiv.org/abs/2103.00020"
+            "\n\n\tdensenet: (32px -224px). Ref: Densely Connected Convolutional Networks "
+            "(2016): https://arxiv.org/abs/1608.06993?source=post_page"
+            "\n\n\tefficientnet: [Tensorflow 2.3+ only] EfficientNet has numerous variants (B0 - "
+            "B8) that increases the model width, depth and dimensional space at each step. The "
+            "minimum input resolution is 32px for all variants. The maximum input resolution for "
+            "each variant is: b0: 224px, b1: 240px, b2: 260px, b3: 300px, b4: 380px, b5: 456px, "
+            "b6: 528px, b7 600px. Ref: Rethinking Model Scaling for Convolutional Neural "
+            "Networks (2020): https://arxiv.org/abs/1905.11946"
+            "\n\n\tefficientnet_v2: [Tensorflow 2.8+ only] EfficientNetV2 is the follow up to "
+            "efficientnet. It has numerous variants (B0 - B3 and Small, Medium and Large) that "
+            "increases the model width, depth and dimensional space at each step. The minimum "
+            "input resolution is 32px for all variants. The maximum input resolution for each "
+            "variant is: b0: 224px, b1: 240px, b2: 260px, b3: 300px, s: 384px, m: 480px, l: "
+            "480px. Ref: EfficientNetV2: Smaller Models and Faster Training (2021): "
+            "https://arxiv.org/abs/2104.00298"
+            "\n\n\tfs_original: (32px - 1024px). A configurable variant of the original facewap "
+            "encoder. ImageNet weights cannot be loaded for this model. Additional parameters "
+            "can be configured with the 'fs_enc' options. A version of this encoder is used in "
+            "the following models: Original, Original (lowmem), Dfaker, DFL-H128, DFL-SAE, IAE, "
+            "Lightweight."
+            "\n\n\tinception_resnet_v2: (75px - 299px). Ref: Inception-ResNet and the Impact of "
+            "Residual Connections on Learning (2016): https://arxiv.org/abs/1602.07261"
+            "\n\n\tinceptionV3: (75px - 299px). Ref: Rethinking the Inception Architecture for "
+            "Computer Vision (2015): https://arxiv.org/abs/1512.00567"
+            "\n\n\tmobilenet: (32px - 224px). Additional MobileNet parameters can be set with "
+            "the 'mobilenet' options. Ref: MobileNets: Efficient Convolutional Neural Networks "
+            "for Mobile Vision Applications (2017): https://arxiv.org/abs/1704.04861"
+            "\n\n\tmobilenet_v2: (32px - 224px). Additional MobileNet parameters can be set with "
+            "the 'mobilenet' options. Ref: MobileNetV2: Inverted Residuals and Linear "
+            "Bottlenecks (2018): https://arxiv.org/abs/1801.04381"
+            "\n\n\tmobilenet_v3: (32px - 224px). Additional MobileNet parameters can be set with "
+            "the 'mobilenet' options. Ref: Searching for MobileNetV3 (2019): "
+            "https://arxiv.org/pdf/1905.02244.pdf"
+            "\n\n\tnasnet: (32px - 331px (large) or 224px (mobile)). Ref: Learning Transferable "
+            "Architectures for Scalable Image Recognition (2017): "
+            "https://arxiv.org/abs/1707.07012"
+            "\n\n\tresnet: (32px - 224px). Deep Residual Learning for Image Recognition (2015): "
+            "https://arxiv.org/abs/1512.03385"
+            "\n\n\tvgg: (32px - 224px). Very Deep Convolutional Networks for Large-Scale Image "
+            "Recognition (2014): https://arxiv.org/abs/1409.1556"
+            "\n\n\txception: (71px - 229px). Ref: Deep Learning with Depthwise Separable "
+            "Convolutions (2017): https://arxiv.org/abs/1409.1556.\n"),
+        "datatype": str,
+        "choices": _ENCODERS,
+        "gui_radio": False,
+        "group": "encoder",
+        "fixed": True},
+    "enc_scaling": {
+        "default": 7,
+        "info": (
+            "Input scaling for the encoder. Some of the encoders have large input sizes, which "
+            "often are not helpful for Faceswap. This setting scales the dimensional space that "
+            "the encoder works in. For example an encoder with a maximum input size of 224px "
+            "will be input an image of 112px at 50%% scaling. See the Architecture tooltip for "
+            "the minimum and maximum sizes for each encoder. NB: The input size will be rounded "
+            "down to the nearest 16 pixels."),
+        "datatype": int,
+        "min_max": (0, 200),
+        "rounding": 1,
+        "group": "encoder",
+        "fixed": True},
+    "enc_load_weights": {
+        "default": True,
+        "info": (
+            "Load pre-trained weights trained on ImageNet data. Only available for non-"
+            "Faceswap encoders (i.e. those not beginning with 'fs'). NB: If you use the global "
+            "'load weights' option and have selected to load weights from a previous model's "
+            "'encoder' or 'keras_encoder' then the weights loaded here will be replaced by the "
+            "weights loaded from your saved model."),
+        "datatype": bool,
+        "group": "encoder",
+        "fixed": True},
+
+    # Bottleneck
+    "bottleneck_type": {
+        "default": "dense",
+        "info": (
+            "The type of layer to use for the bottleneck."
+            "\n\taverage_pooling: Use a Global Average Pooling 2D layer for the bottleneck."
+            "\n\tdense: Use a Dense layer for the bottleneck (the traditional Faceswap method). "
+            "You can set the size of the Dense layer with the 'bottleneck_size' parameter."
+            "\n\tmax_pooling: Use a Global Max Pooling 2D layer for the bottleneck."
+            "\n\flatten: Don't use a bottleneck at all. Some encoders output in a size that make "
+            "a bottleneck unnecessary. This option flattens the output from the encoder, with no "
+            "further operations"),
+        "datatype": str,
+        "group": "bottleneck",
+        "gui_radio": True,
+        "choices": ["average_pooling", "dense", "max_pooling", "flatten"],
+        "fixed": True},
+    "bottleneck_norm": {
+        "default": "none",
+        "info": (
+            "Apply a normalization layer after encoder output and prior to the bottleneck."
+            "\n\tnone - Do not apply a normalization layer"
+            "\n\tinstance - Apply Instance Normalization"
+            "\n\tlayer - Apply Layer Normalization (Ba et al., 2016)"
+            "\n\trms - Apply Root Mean Squared Layer Normalization (Zhang et al., 2019). A "
+            "simplified version of Layer Normalization with reduced overhead."),
+        "datatype": str,
+        "gui_radio": True,
+        "choices": ["none", "instance", "layer", "rms"],
+        "group": "bottleneck",
+        "fixed": True},
+    "bottleneck_size": {
+        "default": 1024,
+        "info": (
+            "If using a Dense layer for the bottleneck, then this is the number of nodes to "
+            "use."),
+        "datatype": int,
+        "rounding": 128,
+        "min_max": (128, 4096),
+        "group": "bottleneck",
+        "fixed": True},
+    "bottleneck_in_encoder": {
+        "default": True,
+        "info": (
+            "Whether to place the bottleneck in the Encoder or to place it with the other "
+            "hidden layers. Placing the bottleneck in the encoder means that both sides will "
+            "share the same bottleneck. Placing it with the other fully connected layers means "
+            "that each fully connected layer will each get their own bottleneck. This may be "
+            "combined or split depending on your overall architecture configuration settings."),
+        "datatype": bool,
+        "group": "bottleneck",
+        "fixed": True},
+
+    # Intermediate Layers
+    "fc_depth": {
+        "default": 1,
+        "info": (
+            "The number of consecutive Dense (fully connected) layers to include in each "
+            "side's intermediate layer."),
+        "datatype": int,
+        "rounding": 1,
+        "min_max": (0, 16),
+        "group": "hidden layers",
+        "fixed": True},
+    "fc_min_filters": {
+        "default": 1024,
+        "info": (
+            "The number of filters to use for the initial fully connected layer. The number of "
+            "nodes actually used is: fc_min_filters x fc_dimensions x fc_dimensions.\nNB: This "
+            "value may be scaled down, depending on output resolution."),
+        "datatype": int,
+        "rounding": 16,
+        "min_max": (16, 5120),
+        "group": "hidden layers",
+        "fixed": True},
+    "fc_max_filters": {
+        "default": 1024,
+        "info": (
+            "This is the number of filters to be used in the final reshape layer at the end of "
+            "the fully connected layers. The actual number of nodes used for the final fully "
+            "connected layer is: fc_min_filters x fc_dimensions x fc_dimensions.\nNB: This value "
+            "may be scaled down, depending on output resolution."),
+        "datatype": int,
+        "rounding": 64,
+        "min_max": (128, 5120),
+        "group": "hidden layers",
+        "fixed": True},
+    "fc_dimensions": {
+        "default": 4,
+        "info": (
+            "The height and width dimension for the final reshape layer at the end of the "
+            "fully connected layers.\nNB: The total number of nodes within the final fully "
+            "connected layer will be: fc_dimensions x fc_dimensions x fc_max_filters."),
+        "datatype": int,
+        "rounding": 1,
+        "min_max": (1, 16),
+        "group": "hidden layers",
+        "fixed": True},
+    "fc_filter_slope": {
+        "default": -0.5,
+        "info": (
+            "The rate that the filters move from the minimum number of filters to the maximum "
+            "number of filters. EG:\n"
+            "Negative numbers will change the number of filters quicker at first and slow down "
+            "each layer.\n"
+            "Positive numbers will change the number of filters slower at first but then speed "
+            "up each layer.\n"
+            "0.0 - This will change at a linear rate (i.e. the same number of filters will be "
+            "changed at each layer)."),
+        "datatype": float,
+        "min_max": (-.99, .99),
+        "rounding": 2,
+        "group": "hidden layers",
+        "fixed": True},
+    "fc_dropout": {
+        "default": 0.0,
+        "info": (
+            "Dropout is a form of regularization that can prevent a model from over-fitting "
+            "and help to keep neurons 'alive'. 0.5 will dropout half the connections between each "
+            "fully connected layer, 0.25 will dropout a quarter of the connections etc. Set to "
+            "0.0 to disable."),
+        "datatype": float,
+        "rounding": 2,
+        "min_max": (0.0, 0.99),
+        "group": "hidden layers",
+        "fixed": False},
+    "fc_upsampler": {
+        "default": "upsample2d",
+        "info": (
+            "The type of dimensional upsampling to perform at the end of the fully connected "
+            "layers, if upsamples > 0. The number of filters used for the upscale layers will be "
+            "the value given in 'fc_upsample_filters'."
+            "\n\tupsample2d - A lightweight and VRAM friendly method. 'quick and dirty' but does "
+            "not learn any parameters"
+            "\n\tsubpixel - Sub-pixel upscaler using depth-to-space which may require more "
+            "VRAM."
+            "\n\tresize_images - Uses the Keras resize_image function to save about half as much "
+            "vram as the heaviest methods."
+            "\n\tupscale_fast - Developed by Andenixa. Focusses on speed to upscale, but "
+            "requires more VRAM."
+            "\n\tupscale_hybrid - Developed by Andenixa. Uses a combination of PixelShuffler and "
+            "Upsampling2D to upscale, saving about 1/3rd of VRAM of the heaviest methods."
+            "\n\tupscale_dny - An alternative upscale implementation using Upsampling2D to upsample."),
+        "datatype": str,
+        "choices": ["resize_images", "subpixel", "upscale_fast", "upscale_hybrid", "upscale_dny", "upsample2d"],
+        "group": "hidden layers",
+        "gui_radio": False,
+        "fixed": True},
+    "fc_upsamples": {
+        "default": 1,
+        "info": (
+            "Some upsampling can occur within the Fully Connected layers rather than in the "
+            "Decoder to increase the dimensional space. Set how many upscale layers should occur "
+            "within the Fully Connected layers."),
+        "datatype": int,
+        "min_max": (0, 4),
+        "rounding": 1,
+        "group": "hidden layers",
+        "fixed": True},
+    "fc_upsample_filters": {
+        "default": 512,
+        "info": (
+            "If you have selected an upsampler which requires filters (i.e. any upsampler with "
+            "the exception of Upsampling2D), then this is the number of filters to be used for "
+            "the upsamplers within the fully connected layers,  NB: This value may be scaled "
+            "down, depending on output resolution. Also note, that this figure will dictate the "
+            "number of filters used for the G-Block, if selected."),
+        "datatype": int,
+        "rounding": 64,
+        "min_max": (128, 5120),
+        "group": "hidden layers",
+        "fixed": True},
+
+    # G-Block
+    "fc_gblock_depth": {
+        "default": 3,
+        "info": (
+            "The number of consecutive Dense (fully connected) layers to include in the "
+            "G-Block shared layer."),
+        "datatype": int,
+        "rounding": 1,
+        "min_max": (1, 16),
+        "group": "g-block hidden layers",
+        "fixed": True},
+    "fc_gblock_min_nodes": {
+        "default": 512,
+        "info": "The number of nodes to use for the initial G-Block shared fully connected layer.",
+        "datatype": int,
+        "rounding": 64,
+        "min_max": (128, 5120),
+        "group": "g-block hidden layers",
+        "fixed": True},
+    "fc_gblock_max_nodes": {
+        "default": 512,
+        "info": "The number of nodes to use for the final G-Block shared fully connected layer.",
+        "datatype": int,
+        "rounding": 64,
+        "min_max": (128, 5120),
+        "group": "g-block hidden layers",
+        "fixed": True},
+    "fc_gblock_filter_slope": {
+        "default": -0.5,
+        "info": (
+            "The rate that the filters move from the minimum number of filters to the maximum "
+            "number of filters for the G-Block shared layers. EG:\n"
+            "Negative numbers will change the number of filters quicker at first and slow down "
+            "each layer.\n"
+            "Positive numbers will change the number of filters slower at first but then speed "
+            "up each layer.\n"
+            "0.0 - This will change at a linear rate (i.e. the same number of filters will be "
+            "changed at each layer)."),
+        "datatype": float,
+        "min_max": (-.99, .99),
+        "rounding": 2,
+        "group": "g-block hidden layers",
+        "fixed": True},
+    "fc_gblock_dropout": {
+        "default": 0.0,
+        "info": (
+            "Dropout is a regularization technique that can prevent a model from over-fitting "
+            "and help to keep neurons 'alive'. 0.5 will dropout half the connections between "
+            "each fully connected layer, 0.25 will dropout a quarter of the connections etc. Set "
+            "to 0.0 to disable."),
+        "datatype": float,
+        "rounding": 2,
+        "min_max": (0.0, 0.99),
+        "group": "g-block hidden layers",
+        "fixed": False},
+
+    # Decoder
+    "dec_upscale_method": {
+        "default": "subpixel",
+        "info": (
+            "The method to use for the upscales within the decoder. Images are upscaled "
+            "multiple times within the decoder as the network learns to reconstruct the face."
+            "\n\tsubpixel - Sub-pixel upscaler using depth-to-space which requires more "
+            "VRAM."
+            "\n\tresize_images - Uses the Keras resize_image function to save about half as much "
+            "vram as the heaviest methods."
+            "\n\tupscale_fast - Developed by Andenixa. Focusses on speed to upscale, but "
+            "requires more VRAM."
+            "\n\tupscale_hybrid - Developed by Andenixa. Uses a combination of PixelShuffler and "
+            "Upsampling2D to upscale, saving about 1/3rd of VRAM of the heaviest methods."
+            "\n\tupscale_dny - An alternative upscale implementation using Upsampling2D to upsample."),
+            "\n\tupscale_dny - An alternative upscale implementation using Upsampling2D to "
+            "upsale."),
+        "datatype": str,
+        "choices": ["subpixel", "resize_images", "upscale_fast", "upscale_hybrid", "upscale_dny"],
+        "gui_radio": True,
+        "group": "decoder",
+        "fixed": True},
+    "dec_upscales_in_fc": {
+        "default": 0,
+        "min_max": (0, 6),
+        "rounding": 1,
+        "info": (
+            "It is possible to place some of the upscales at the end of the fully connected "
+            "model. For models with split decoders, but a shared fully connected layer, this "
+            "would have the effect of saving some VRAM but possibly at the cost of introducing "
+            "artefacts. For models with a shared decoder but split fully connected layers, this "
+            "would have the effect of increasing VRAM usage by processing some of the upscales "
+            "for each side rather than together."),
+        "datatype": int,
+        "group": "decoder",
+        "fixed": True},
+    "dec_norm": {
+        "default": "none",
+        "info": (
+            "Normalization to apply to apply after each upscale."
+            "\n\tnone - Do not apply a normalization layer"
+            "\n\tbatch - Apply Batch Normalization"
+            "\n\tgroup - Apply Group Normalization"
+            "\n\tinstance - Apply Instance Normalization"
+            "\n\tlayer - Apply Layer Normalization (Ba et al., 2016)"
+            "\n\trms - Apply Root Mean Squared Layer Normalization (Zhang et al., 2019). A "
+            "simplified version of Layer Normalization with reduced overhead."),
+        "datatype": str,
+        "gui_radio": True,
+        "choices": ["none", "batch", "group", "instance", "layer", "rms"],
+        "group": "decoder",
+        "fixed": True},
+    "dec_min_filters": {
+        "default": 64,
+        "info": (
+            "The minimum number of filters to use in decoder upscalers (i.e. the number of "
+            "filters to use for the final upscale layer)."),
+        "datatype": int,
+        "min_max": (16, 512),
+        "rounding": 16,
+        "group": "decoder",
+        "fixed": True},
+    "dec_max_filters": {
+        "default": 512,
+        "info": (
+            "The maximum number of filters to use in decoder upscalers (i.e. the number of "
+            "filters to use for the first upscale layer)."),
+        "datatype": int,
+        "min_max": (256, 5120),
+        "rounding": 64,
+        "group": "decoder",
+        "fixed": True},
+    "dec_slope_mode": {
+        "default": "full",
+        "info": (
+            "Alters the action of the filter slope.\n"
+            "\n\tfull: The number of filters at each upscale layer will reduce from the chosen "
+            "max_filters at the first layer to the chosen min_filters at the last layer as "
+            "dictated by the dec_filter_slope."
+            "\n\tcap_max: The filters will decline at a fixed rate from each upscale to the next "
+            "based on the filter_slope setting. If there are more upscales than filters, "
+            "then the earliest upscales will be capped at the max_filter value until the filters "
+            "can reduce to the min_filters value at the final upscale. (EG: 512 -> 512 -> 512 -> "
+            "256 -> 128 -> 64)."
+            "\n\tcap_min: The filters will decline at a fixed rate from each upscale to the next "
+            "based on the filter_slope setting. If there are more upscales than filters, then "
+            "the earliest upscales will drop their filters until the min_filter value is met and "
+            "repeat the min_filter value for the remaining upscales. (EG: 512 -> 256 -> 128 -> "
+            "64 -> 64 -> 64)."),
+        "choices": ["full", "cap_max", "cap_min"],
+        "group": "decoder",
+        "fixed": True,
+        "gui_radio": True},
+    "dec_filter_slope": {
+        "default": -0.45,
+        "info": (
+            "The rate that the filters reduce at each upscale layer.\n"
+            "\n\tFull Slope Mode: Negative numbers will drop the number of filters quicker at "
+            "first and slow down each upscale. Positive numbers will drop the number of filters "
+            "slower at first but then speed up each upscale. A value of 0.0 will reduce at a "
+            "linear rate (i.e. the same number of filters will be reduced at each upscale).\n"
+            "\n\tCap Min/Max Slope Mode: Only positive values will work here. Negative values "
+            "will automatically be converted to their positive counterpart. A value of 0.5 will "
+            "halve the number of filters at each upscale until the minimum value is reached. A "
+            "value of 0.33 will be reduce the number of filters by a third until the minimum "
+            "value is reached etc."),
+        "datatype": float,
+        "min_max": (-.99, .99),
+        "rounding": 2,
+        "group": "decoder",
+        "fixed": True},
+    "dec_res_blocks": {
+        "default": 1,
+        "info": (
+            "The number of Residual Blocks to apply to each upscale layer. Set to 0 to disable "
+            "residual blocks entirely."),
+        "datatype": int,
+        "rounding": 1,
+        "min_max": (0, 8),
+        "group": "decoder",
+        "fixed": True},
+    "dec_output_kernel": {
+        "default": 5,
+        "info": "The kernel size to apply to the final Convolution layer.",
+        "datatype": int,
+        "rounding": 2,
+        "min_max": (1, 9),
+        "group": "decoder",
+        "fixed": True},
+    "dec_gaussian": {
+        "default": True,
+        "info": (
+            "Gaussian Noise acts as a regularization technique for preventing overfitting of "
+            "data."
+            "\n\tTrue - Apply a Gaussian Noise layer to each upscale."
+            "\n\tFalse - Don't apply a Gaussian Noise layer to each upscale."),
+        "datatype": bool,
+        "group": "decoder",
+        "fixed": True},
+    "dec_skip_last_residual": {
+        "default": True,
+        "info": (
+            "If Residual blocks have been enabled, enabling this option will not apply a "
+            "Residual block to the final upscaler."
+            "\n\tTrue - Don't apply a Residual block to the final upscale."
+            "\n\tFalse - Apply a Residual block to all upscale layers."),
+        "datatype": bool,
+        "group": "decoder",
+        "fixed": True},
+
+    # Weight management
+    "freeze_layers": {
+        "default": "keras_encoder",
+        "info": (
+            "If the command line option 'freeze-weights' is enabled, then the layers indicated "
+            "here will be frozen the next time the model starts up. NB: Not all architectures "
+            "contain all of the layers listed here, so any layers marked for freezing that are "
+            "not within your chosen architecture will be ignored. EG:\n If 'split fc' has "
+            "been selected, then 'fc_a' and 'fc_b' are available for freezing. If it has "
+            "not been selected then 'fc_both' is available for freezing."),
+        "datatype": list,
+        "choices": ["encoder", "keras_encoder", "fc_a", "fc_b", "fc_both", "fc_shared",
+                    "fc_gblock", "g_block_a", "g_block_b", "g_block_both", "decoder_a",
+                    "decoder_b", "decoder_both"],
+        "group": "weights",
+        "fixed": False},
+    "load_layers": {
+        "default": "encoder",
+        "info": (
+            "If the command line option 'load-weights' is populated, then the layers indicated "
+            "here will be loaded from the given weights file if starting a new model. NB Not all "
+            "architectures contain all of the layers listed here, so any layers marked for "
+            "loading that are not within your chosen architecture will be ignored. EG:\n If "
+            "'split fc' has been selected, then 'fc_a' and 'fc_b' are available for loading. If "
+            "it has not been selected then 'fc_both' is available for loading."),
+        "datatype": list,
+        "choices": ["encoder", "fc_a", "fc_b", "fc_both", "fc_shared", "fc_gblock", "g_block_a",
+                    "g_block_b", "g_block_both", "decoder_a", "decoder_b", "decoder_both"],
+        "group": "weights",
+        "fixed": True},
+
+    # # SPECIFIC ENCODER SETTINGS # #
+    # Faceswap Original
+    "fs_original_depth": {
+        "default": 4,
+        "info": "Faceswap Encoder only: The number of convolutions to perform within the encoder.",
+        "datatype": int,
+        "min_max": (2, 10),
+        "rounding": 1,
+        "group": "faceswap encoder configuration",
+        "fixed": True},
+    "fs_original_min_filters": {
+        "default": 128,
+        "info": (
+            "Faceswap Encoder only: The minumum number of filters to use for encoder "
+            "convolutions. (i.e. the number of filters to use for the first encoder layer)."),
+        "datatype": int,
+        "min_max": (16, 2048),
+        "rounding": 64,
+        "group": "faceswap encoder configuration",
+        "fixed": True},
+    "fs_original_max_filters": {
+        "default": 1024,
+        "info": (
+            "Faceswap Encoder only: The maximum number of filters to use for encoder "
+            "convolutions. (i.e. the number of filters to use for the final encoder layer)."),
+        "datatype": int,
+        "min_max": (256, 8192),
+        "rounding": 128,
+        "group": "faceswap encoder configuration",
+        "fixed": True},
+    "fs_original_use_alt": {
+        "default": False,
+        "info": (
+            "Use a slightly alternate version of the Faceswap Encoder."
+            "\n\tTrue - Use the alternate variation of the Faceswap Encoder."
+            "\n\tFalse - Use the original Faceswap Encoder."),
+        "datatype": bool,
+        "group": "faceswap encoder configuration",
+        "fixed": True},
+
+    # MobileNet
+    "mobilenet_width": {
+        "default": 1.0,
+        "info": (
+            "The width multiplier for mobilenet encoders. Controls the width of the "
+            "network. Values less than 1.0 proportionally decrease the number of filters within "
+            "each layer. Values greater than 1.0 proportionally increase the number of filters "
+            "within each layer. 1.0 is the default number of layers used within the paper.\n"
+            "NB: This option is ignored for any non-mobilenet encoders.\n"
+            "NB: If loading ImageNet weights, then for MobilenetV1 only values of '0.25', "
+            "'0.5', '0.75' or '1.0 can be selected. For MobilenetV2 only values of '0.35', "
+            "'0.50', '0.75', '1.0', '1.3' or '1.4' can be selected. For mobilenet_v3 only values "
+            "of '0.75' or '1.0' can be selected"),
+        "datatype": float,
+        "min_max": (0.1, 2.0),
+        "rounding": 2,
+        "group": "mobilenet encoder configuration",
+        "fixed": True},
+    "mobilenet_depth": {
+        "default": 1,
+        "info": (
+            "The depth multiplier for MobilenetV1 encoder. This is the depth multiplier "
+            "for depthwise convolution (known as the resolution multiplier within the original "
+            "paper).\n"
+            "NB: This option is only used for MobilenetV1 and is ignored for all other "
+            "encoders.\n"
+            "NB: If loading ImageNet weights, this must be set to 1."),
+        "datatype": int,
+        "min_max": (1, 10),
+        "rounding": 1,
+        "group": "mobilenet encoder configuration",
+        "fixed": True},
+    "mobilenet_dropout": {
+        "default": 0.001,
+        "info": (
+            "The dropout rate for MobilenetV1 encoder.\n"
+            "NB: This option is only used for MobilenetV1 and is ignored for all other "
+            "encoders."),
+        "datatype": float,
+        "min_max": (0.001, 2.0),
+        "rounding": 3,
+        "group": "mobilenet encoder configuration",
+        "fixed": True},
+    "mobilenet_minimalistic": {
+        "default": False,
+        "info": (
+            "Use a minimilist version of MobilenetV3.\n"
+            "In addition to large and small models MobilenetV3 also contains so-called "
+            "minimalistic models, these models have the same per-layer dimensions characteristic "
+            "as MobilenetV3 however, they don't utilize any of the advanced blocks "
+            "(squeeze-and-excite units, hard-swish, and 5x5 convolutions). While these models "
+            "are less efficient on CPU, they are much more performant on GPU/DSP.\n"
+            "NB: This option is only used for MobilenetV3 and is ignored for all other "
+            "encoders.\n"),
+        "datatype": bool,
+        "group": "mobilenet encoder configuration",
+        "fixed": True},
+    }


### PR DESCRIPTION
## Summary
- Add `phaze_a_custom` model and defaults exposing the DNY upscaler
- Document new upscaler option and wire custom model into CLI help

## Testing
- `pytest tests/simple_tests.py -q` *(no tests found)*
- `python faceswap.py train -h` *(fails: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_689e2ef07cb0832e98354508605664dd