### PR TITLE
Add PatchGAN discriminator constructor

### DIFF
--- a/lib/model/discriminators/__init__.py
+++ b/lib/model/discriminators/__init__.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+"""Discriminator models for Faceswap."""
+from .patch_gan import build_patch_discriminator
+
+__all__ = ["build_patch_discriminator"]

--- a/lib/model/discriminators/patch_gan.py
+++ b/lib/model/discriminators/patch_gan.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""PatchGAN discriminator constructor."""
+from __future__ import annotations
+
+import tensorflow as tf
+
+# Fix intellisense/linting for tf.keras' import system
+keras = tf.keras
+layers = keras.layers
+Model = keras.models.Model
+
+
+def build_patch_discriminator(input_shape: tuple[int, int, int],
+                              base_filters: int = 64) -> Model:
+    """Build a PatchGAN discriminator model.
+
+    Parameters
+    ----------
+    input_shape: tuple[int, int, int]
+        Input shape ``(height, width, channels)``.
+    base_filters: int, optional
+        Number of filters for the first convolutional layer.
+
+    Returns
+    -------
+    Model
+        A Keras :class:`~tensorflow.keras.models.Model` producing an ``N x N`` score map.
+    """
+    inputs = layers.Input(shape=input_shape)
+    x = inputs
+    filters = base_filters
+
+    # Downsampling blocks
+    for _ in range(3):
+        x = layers.Conv2D(filters, kernel_size=4, strides=2, padding="same")(x)
+        x = layers.LeakyReLU(0.2)(x)
+        x = layers.BatchNormalization()(x)
+        filters *= 2
+
+    # Final score map
+    outputs = layers.Conv2D(1, kernel_size=1, padding="same")(x)
+    model = Model(inputs, outputs, name="PatchGANDiscriminator")
+    return model


### PR DESCRIPTION
## Summary
- add PatchGAN discriminator builder using Conv2D/LeakyReLU/BatchNorm blocks
- expose `build_patch_discriminator` through discriminators package

## Testing
- `python -m pytest -q` *(fails: No module named 'pytest_mock')*

------
https://chatgpt.com/codex/tasks/task_e_68b346571758832e832d857731a0acb1