### PR TITLE
Add configurable third decoder support to original-based models

### DIFF
--- a/plugins/train/model/dfaker.py
+++ b/plugins/train/model/dfaker.py
@@ -46,7 +46,7 @@ class Model(OriginalModel):
         var_x = Conv2DOutput(3, 5, name=f"face_out_{side}")(var_x)
         outputs = [var_x]
 
-        if self.config.get("learn_mask", False):
+        if self.learn_mask:
             var_y = input_
             if self._output_size == 256:
                 var_y = UpscaleBlock(1024, activation="leakyrelu")(var_y)

--- a/plugins/train/model/dfaker_defaults.py
+++ b/plugins/train/model/dfaker_defaults.py
@@ -54,4 +54,16 @@ _DEFAULTS = dict(
         rounding=128,
         min_max=(128, 256),
         group="size",
-        fixed=True))
+        fixed=True),
+    third_side=dict(
+        default=False,
+        info="Enable an additional 'C' decoder head. Existing checkpoints trained without this "
+             "option remain two-sided and are not compatible with the extra decoder.",
+        datatype=bool,
+        rounding=None,
+        min_max=None,
+        choices=[],
+        gui_radio=False,
+        fixed=True,
+        group="settings",
+    ))

--- a/plugins/train/model/original.py
+++ b/plugins/train/model/original.py
@@ -44,6 +44,9 @@ class Model(ModelBase):
         self.low_mem = self.config.get("lowmem", False)
         self.learn_mask = self.config["learn_mask"]
         self.encoder_dim = 512 if self.low_mem else 1024
+        self.sides = ["a", "b"]
+        if self.config.get("third_side", False):
+            self.sides.append("c")
 
     def build_model(self, inputs):
         """ Create the model's structure.
@@ -68,8 +71,8 @@ class Model(ModelBase):
         Parameters
         ----------
         inputs: list
-            A list of input tensors for the model. This will be a list of 2 tensors of
-            shape :attr:`input_shape`, the first for side "a", the second for side "b".
+            A list of input tensors for the model. This will be a list of
+            ``len(self.sides)`` tensors of shape :attr:`input_shape`, one per configured side.
 
         Returns
         -------
@@ -79,17 +82,27 @@ class Model(ModelBase):
             argument in Faceswap. You should assign this to the attribute ``self.name`` that is
             automatically generated from the plugin's filename.
         """
-        input_a = inputs[0]
-        input_b = inputs[1]
+        if len(inputs) != len(self.sides):
+            raise ValueError("Number of inputs does not match configured sides: "
+                             f"{len(inputs)} provided for {len(self.sides)} sides")
 
         encoder = self.encoder()
-        encoder_a = [encoder(input_a)]
-        encoder_b = [encoder(input_b)]
+        decoders = {side: self.decoder(side) for side in self.sides}
+        outputs = []
 
-        outputs = self.decoder("a")(encoder_a) + self.decoder("b")(encoder_b)
+        for side, input_tensor in zip(self.sides, inputs):
+            encoded = encoder(input_tensor)
+            outputs.extend(decoders[side]([encoded]))
 
         autoencoder = KModel(inputs, outputs, name=self.model_name)
         return autoencoder
+
+    def _get_inputs(self):
+        """ Obtain model inputs for each configured side. """
+        input_shapes = [self.input_shape for _ in self.sides]
+        inputs = [Input(shape=shape, name=f"face_in_{side}")
+                  for side, shape in zip(self.sides, input_shapes)]
+        return inputs
 
     def encoder(self):
         """ The original Faceswap Encoder Network.

--- a/plugins/train/model/original_defaults.py
+++ b/plugins/train/model/original_defaults.py
@@ -60,4 +60,16 @@ _DEFAULTS = dict(
         fixed=True,
         group="settings",
     ),
+    third_side=dict(
+        default=False,
+        info="Enable an additional 'C' decoder head. Existing checkpoints trained without this "
+             "option remain two-sided and are not compatible with the extra decoder.",
+        datatype=bool,
+        rounding=None,
+        min_max=None,
+        choices=[],
+        gui_radio=False,
+        fixed=True,
+        group="settings",
+    ),
 )

--- a/tests/plugins/train/model/test_triple_decoder_outputs.py
+++ b/tests/plugins/train/model/test_triple_decoder_outputs.py
@@ -1,0 +1,81 @@
+"""Smoke tests for triple decoder support in Original and DFaker models."""
+import pytest
+
+_ = pytest.importorskip("keras")
+from keras import backend as K, initializers
+
+from plugins.train.model.original import Model as OriginalModel
+from plugins.train.model.dfaker import Model as DFakerModel
+
+
+@pytest.fixture(autouse=True)
+def cleanup_keras_session():
+    """Ensure we don't leak graph state between tests."""
+    yield
+    K.clear_session()
+
+
+def _collect_output_names(model: OriginalModel) -> list[str]:
+    inputs = model._get_inputs()
+    autoencoder = model.build_model(inputs)
+    return [tensor.name for tensor in autoencoder.outputs]
+
+
+def _expected_sequence(sides: list[str], learn_mask: bool) -> list[str]:
+    sequence: list[str] = []
+    for side in sides:
+        sequence.append(f"face_out_{side}")
+        if learn_mask:
+            sequence.append(f"mask_out_{side}")
+    return sequence
+
+
+def _init_original(third_side: bool, learn_mask: bool) -> OriginalModel:
+    model = OriginalModel.__new__(OriginalModel)
+    model.input_shape = (64, 64, 3)
+    model.low_mem = False
+    model.learn_mask = learn_mask
+    model.encoder_dim = 1024
+    model.sides = ["a", "b"] + (["c"] if third_side else [])
+    return model
+
+
+def _init_dfaker(third_side: bool, learn_mask: bool, output_size: int = 128) -> DFakerModel:
+    model = DFakerModel.__new__(DFakerModel)
+    model.input_shape = (output_size // 2, output_size // 2, 3)
+    model.low_mem = False
+    model.learn_mask = learn_mask
+    model.encoder_dim = 1024
+    model._output_size = output_size
+    model.kernel_initializer = initializers.RandomNormal(0, 0.02)
+    model.sides = ["a", "b"] + (["c"] if third_side else [])
+    return model
+
+
+@pytest.mark.parametrize("learn_mask", [False, True], ids=["faces_only", "faces_and_masks"])
+def test_original_outputs_are_ordered(learn_mask: bool) -> None:
+    model = _init_original(third_side=True, learn_mask=learn_mask)
+    outputs = _collect_output_names(model)
+    expected = _expected_sequence(model.sides, learn_mask)
+    assert len(outputs) == len(expected)
+    for name, fragment in zip(outputs, expected):
+        assert fragment in name
+
+
+@pytest.mark.parametrize("learn_mask", [False, True], ids=["faces_only", "faces_and_masks"])
+def test_dfaker_outputs_are_ordered(learn_mask: bool) -> None:
+    model = _init_dfaker(third_side=True, learn_mask=learn_mask)
+    outputs = _collect_output_names(model)
+    expected = _expected_sequence(model.sides, learn_mask)
+    assert len(outputs) == len(expected)
+    for name, fragment in zip(outputs, expected):
+        assert fragment in name
+
+
+def test_original_default_two_sided() -> None:
+    model = _init_original(third_side=False, learn_mask=False)
+    outputs = _collect_output_names(model)
+    expected = _expected_sequence(model.sides, False)
+    assert len(outputs) == len(expected) == 2
+    for name, fragment in zip(outputs, expected):
+        assert fragment in name


### PR DESCRIPTION
## Summary
- add a configurable `third_side` option and iterate over configured sides when building Original/DFaker decoders
- update defaults and decoder mask handling so additional heads mirror existing pattern
- add smoke tests that exercise triple-decoder builds and validate output ordering

## Testing
- pytest tests/plugins/train/model/test_triple_decoder_outputs.py

------
https://chatgpt.com/codex/tasks/task_e_68fbd3bde9a0832ea369a658d408c35c