### PR TITLE
Add optional C-side dataset support

### DIFF
--- a/lib/cli/args_train.py
+++ b/lib/cli/args_train.py
@@ -27,7 +27,8 @@ class TrainArgs(FaceSwapArgs):
         str
             The information text for the Train command.
         """
-        return _("Train a model on extracted original (A) and swap (B) faces.\n"
+        return _("Train a model on extracted original (A) and swap (B) faces, optionally adding "
+                 "a third dataset (C) when supported by the selected model.\n"
                  "Training models can take a long time. Anything from 24hrs to over a week\n"
                  "Model plugins can be configured in the 'Settings' Menu")
 
@@ -59,6 +60,16 @@ class TrainArgs(FaceSwapArgs):
             "help": _(
                 "Input directory. A directory containing training images for face B. This is the "
                 "swap face, i.e. the face that you want to place onto the head of person A.")})
+        argument_list.append({
+            "opts": ("-C", "--input-C"),
+            "action": DirFullPaths,
+            "dest": "input_c",
+            "required": False,
+            "default": None,
+            "group": _("faces"),
+            "help": _(
+                "Optional input directory for face C. Provide this when enabling the third "
+                "decoder in compatible models to train on an additional dataset.")})
         argument_list.append({
             "opts": ("-m", "--model-dir"),
             "action": DirFullPaths,
@@ -250,6 +261,15 @@ class TrainArgs(FaceSwapArgs):
                 "the input folder of 'B' faces that you would like to use for creating the "
                 "timelapse. You must also supply a --timelapse-output and a --timelapse-input-A "
                 "parameter.")})
+        argument_list.append({
+            "opts": ("-v", "--timelapse-input-C"),
+            "action": DirFullPaths,
+            "dest": "timelapse_input_c",
+            "default": None,
+            "group": _("timelapse"),
+            "help": _(
+                "Optional timelapse source for face C. Supply this when training with a third "
+                "decoder to capture time-lapse frames for side C.")})
         argument_list.append({
             "opts": ("-z", "--timelapse-output"),
             "action": DirFullPaths,

--- a/plugins/train/model/dfaker_defaults.py
+++ b/plugins/train/model/dfaker_defaults.py
@@ -58,7 +58,9 @@ _DEFAULTS = dict(
     third_side=dict(
         default=False,
         info="Enable an additional 'C' decoder head. Existing checkpoints trained without this "
-             "option remain two-sided and are not compatible with the extra decoder.",
+             "option remain two-sided and are not compatible with the extra decoder. Provide an "
+             "--input-C folder when enabling this option to supply training data for the third "
+             "side.",
         datatype=bool,
         rounding=None,
         min_max=None,

--- a/plugins/train/model/original.py
+++ b/plugins/train/model/original.py
@@ -6,10 +6,15 @@ This model is heavily documented as it acts as a template that other model plugi
 from.
 """
 
+import logging
+
 from keras import Input, layers, Model as KModel
 
 from lib.model.nn_blocks import Conv2DOutput, Conv2DBlock, UpscaleBlock
 from ._base import ModelBase
+
+
+logger = logging.getLogger(__name__)
 
 
 class Model(ModelBase):
@@ -45,8 +50,17 @@ class Model(ModelBase):
         self.learn_mask = self.config["learn_mask"]
         self.encoder_dim = 512 if self.low_mem else 1024
         self.sides = ["a", "b"]
-        if self.config.get("third_side", False):
+        third_side_enabled = self.config.get("third_side", False)
+        has_input_c = bool(getattr(self.command_line_arguments, "input_c", None))
+        if third_side_enabled and not has_input_c:
+            logger.warning("The third decoder is enabled but no --input-C folder was provided. "
+                           "Disabling the additional side for this session.")
+            self.config["third_side"] = False
+        elif third_side_enabled and has_input_c:
             self.sides.append("c")
+        elif has_input_c and not third_side_enabled:
+            logger.warning("An --input-C folder was supplied but the third decoder is disabled. "
+                           "The extra dataset will not be used.")
 
     def build_model(self, inputs):
         """ Create the model's structure.

--- a/plugins/train/model/original_defaults.py
+++ b/plugins/train/model/original_defaults.py
@@ -63,7 +63,9 @@ _DEFAULTS = dict(
     third_side=dict(
         default=False,
         info="Enable an additional 'C' decoder head. Existing checkpoints trained without this "
-             "option remain two-sided and are not compatible with the extra decoder.",
+             "option remain two-sided and are not compatible with the extra decoder. Provide an "
+             "--input-C folder when enabling this option to supply training data for the third "
+             "side.",
         datatype=bool,
         rounding=None,
         min_max=None,

--- a/plugins/train/trainer/original_defaults.py
+++ b/plugins/train/trainer/original_defaults.py
@@ -49,7 +49,8 @@ _HELPTEXT = ("Original Trainer Options.\n"
 _DEFAULTS = dict(
     preview_images=dict(
         default=14,
-        info="Number of sample faces to display for each side in the preview when training.",
+        info="Number of sample faces to display for each configured side (A/B and optional C) "
+             "in the preview when training.",
         datatype=int,
         rounding=2,
         min_max=(2, 16),

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -29,6 +29,7 @@ if T.TYPE_CHECKING:
 
 
 logger = logging.getLogger(__name__)
+SideLiteral = T.Literal["a", "b", "c"]
 
 
 class Train():
@@ -67,7 +68,7 @@ class Train():
 
         logger.debug("Initialized %s", self.__class__.__name__)
 
-    def _get_images(self) -> dict[T.Literal["a", "b"], list[str]]:
+    def _get_images(self) -> dict[SideLiteral, list[str]]:
         """ Check the image folders exist and contains valid extracted faces. Obtain image paths.
 
         Returns
@@ -77,9 +78,12 @@ class Train():
             for that side.
         """
         logger.debug("Getting image paths")
-        images = {}
-        for side in ("a", "b"):
-            side = T.cast(T.Literal["a", "b"], side)
+        images: dict[SideLiteral, list[str]] = {}
+        sides: list[SideLiteral] = ["a", "b"]
+        if getattr(self._args, "input_c", None):
+            sides.append(T.cast(SideLiteral, "c"))
+
+        for side in sides:
             image_dir = getattr(self._args, f"input_{side}")
             if not os.path.isdir(image_dir):
                 logger.error("Error: '%s' does not exist", image_dir)
@@ -108,7 +112,7 @@ class Train():
         return images
 
     @classmethod
-    def _validate_image_counts(cls, images: dict[T.Literal["a", "b"], list[str]]) -> None:
+    def _validate_image_counts(cls, images: dict[SideLiteral, list[str]]) -> None:
         """ Validate that there are sufficient images to commence training without raising an
         error.
 
@@ -136,7 +140,7 @@ class Train():
                            "Results are likely to be poor.")
             logger.warning(msg)
 
-    def _set_timelapse(self) -> dict[T.Literal["input_a", "input_b", "output"], str]:
+    def _set_timelapse(self) -> dict[str, str]:
         """ Set time-lapse paths if requested.
 
         Returns
@@ -145,12 +149,15 @@ class Train():
             The time-lapse keyword arguments for passing to the trainer
 
         """
-        if (not self._args.timelapse_input_a and
-                not self._args.timelapse_input_b and
-                not self._args.timelapse_output):
+        timelapse_inputs: dict[str, str | None] = {
+            "a": getattr(self._args, "timelapse_input_a", None),
+            "b": getattr(self._args, "timelapse_input_b", None),
+            "c": getattr(self._args, "timelapse_input_c", None)}
+
+        if not any(timelapse_inputs.values()) and not self._args.timelapse_output:
             return {}
-        if (not self._args.timelapse_input_a or
-                not self._args.timelapse_input_b or
+        if (not timelapse_inputs["a"] or
+                not timelapse_inputs["b"] or
                 not self._args.timelapse_output):
             raise FaceswapError("To enable the timelapse, you have to supply all the parameters "
                                 "(--timelapse-input-A, --timelapse-input-B and "
@@ -158,9 +165,12 @@ class Train():
 
         timelapse_output = get_folder(self._args.timelapse_output)
 
-        for side in ("a", "b"):
-            side = T.cast(T.Literal["a", "b"], side)
-            folder = getattr(self._args, f"timelapse_input_{side}")
+        for side, folder in timelapse_inputs.items():
+            if folder is None:
+                continue
+            if side == "c" and side not in self._images:
+                raise FaceswapError("A timelapse input was supplied for side 'C' without "
+                                    "providing --input-C data.")
             if folder is not None and not os.path.isdir(folder):
                 raise FaceswapError(f"The Timelapse path '{folder}' does not exist")
 
@@ -176,15 +186,16 @@ class Train():
 
             # Time-lapse images must appear in the training set, as we need access to alignment and
             # mask info. Check filenames are there to save failing much later in the process.
-            training_images = [os.path.basename(img) for img in self._images[side]]
+            training_images = [os.path.basename(img) for img in self._images[T.cast(SideLiteral, side)]]
             if not all(img in training_images for img in filenames):
                 raise FaceswapError(f"All images in the Timelapse folder '{folder}' must exist in "
                                     f"the training folder '{training_folder}'")
 
-        TKey = T.Literal["input_a", "input_b", "output"]
-        kwargs = {T.cast(TKey, "input_a"): self._args.timelapse_input_a,
-                  T.cast(TKey, "input_b"): self._args.timelapse_input_b,
-                  T.cast(TKey, "output"): timelapse_output}
+        kwargs: dict[str, str] = {"input_a": T.cast(str, timelapse_inputs["a"]),
+                                  "input_b": T.cast(str, timelapse_inputs["b"]),
+                                  "output": timelapse_output}
+        if timelapse_inputs["c"]:
+            kwargs["input_c"] = T.cast(str, timelapse_inputs["c"])
         logger.debug("Timelapse enabled: %s", kwargs)
         return kwargs
 
@@ -281,9 +292,24 @@ class Train():
             model_dir,
             self._args,
             predict=False)
+        if not self._args.summary:
+            self._persist_dataset_paths(model)
         model.build()
         logger.debug("Loaded Model")
         return model
+
+    def _persist_dataset_paths(self, model: "ModelBase") -> None:
+        """Store the dataset paths used for this session in the model state."""
+
+        datasets = model.state.current_session.setdefault("datasets", {})
+        for side in ("a", "b", "c"):
+            key = f"input_{side}"
+            path = getattr(self._args, key, None)
+            if path:
+                datasets[key] = path
+            else:
+                datasets.pop(key, None)
+        model.state.save()
 
     def _load_trainer(self, model: ModelBase) -> TrainerBase:
         """ Load the trainer requested for training.


### PR DESCRIPTION
## Summary
- add optional `--input-C` and matching timelapse flag to the training CLI help text
- update training to validate an optional third dataset, adjust timelapse handling, and store dataset paths in the model state
- auto-disable the third decoder when no C data is supplied and document the requirement in model and trainer defaults

## Testing
- pytest tests/plugins/train/model/test_triple_decoder_outputs.py

------
https://chatgpt.com/codex/tasks/task_e_68fbf4979504832e948c92aea7734411